### PR TITLE
fix: decouple isTransitioning from action status to fix onSuccess wit…

### DIFF
--- a/packages/next-safe-action/src/hooks-utils.ts
+++ b/packages/next-safe-action/src/hooks-utils.ts
@@ -7,14 +7,12 @@ import type { InferInputOrDefault, StandardSchemaV1 } from "./standard-schema";
 export const getActionStatus = <ServerError, S extends StandardSchemaV1 | undefined, CVE, Data>({
 	isIdle,
 	isExecuting,
-	isTransitioning,
 	result,
 	hasNavigated,
 	hasThrownError,
 }: {
 	isIdle: boolean;
 	isExecuting: boolean;
-	isTransitioning: boolean;
 	hasNavigated: boolean;
 	hasThrownError: boolean;
 	result: SafeActionResult<ServerError, S, CVE, Data>;
@@ -23,8 +21,6 @@ export const getActionStatus = <ServerError, S extends StandardSchemaV1 | undefi
 		return "idle";
 	} else if (isExecuting) {
 		return "executing";
-	} else if (isTransitioning) {
-		return "transitioning";
 	} else if (
 		hasThrownError ||
 		typeof result.validationErrors !== "undefined" ||
@@ -38,12 +34,15 @@ export const getActionStatus = <ServerError, S extends StandardSchemaV1 | undefi
 	}
 };
 
-export const getActionShorthandStatusObject = (status: HookActionStatus): HookShorthandStatus => {
+export const getActionShorthandStatusObject = (
+	status: HookActionStatus,
+	isTransitioning: boolean
+): HookShorthandStatus => {
 	return {
 		isIdle: status === "idle",
 		isExecuting: status === "executing",
-		isTransitioning: status === "transitioning",
-		isPending: status === "executing" || status === "transitioning",
+		isTransitioning,
+		isPending: status === "executing" || isTransitioning,
 		hasSucceeded: status === "hasSucceeded",
 		hasErrored: status === "hasErrored",
 		hasNavigated: status === "hasNavigated",
@@ -89,8 +88,6 @@ export const useActionCallbacks = <ServerError, S extends StandardSchemaV1 | und
 			switch (status) {
 				case "executing":
 					await Promise.resolve(onExecute?.({ input })).then(() => {});
-					break;
-				case "transitioning":
 					break;
 				case "hasSucceeded":
 					if (navigationError || thrownError) {

--- a/packages/next-safe-action/src/hooks.ts
+++ b/packages/next-safe-action/src/hooks.ts
@@ -35,7 +35,6 @@ export const useAction = <ServerError, S extends StandardSchemaV1 | undefined, C
 
 	const status = getActionStatus<ServerError, S, CVE, Data>({
 		isExecuting,
-		isTransitioning,
 		result,
 		isIdle,
 		hasNavigated: navigationError !== null,
@@ -137,7 +136,7 @@ export const useAction = <ServerError, S extends StandardSchemaV1 | undefined, C
 		result,
 		reset,
 		status,
-		...getActionShorthandStatusObject(status),
+		...getActionShorthandStatusObject(status, isTransitioning),
 	};
 };
 
@@ -169,7 +168,6 @@ export const useOptimisticAction = <ServerError, S extends StandardSchemaV1 | un
 
 	const status = getActionStatus<ServerError, S, CVE, Data>({
 		isExecuting,
-		isTransitioning,
 		result,
 		isIdle,
 		hasNavigated: navigationError !== null,
@@ -280,7 +278,7 @@ export const useOptimisticAction = <ServerError, S extends StandardSchemaV1 | un
 		optimisticState,
 		reset,
 		status,
-		...getActionShorthandStatusObject(status),
+		...getActionShorthandStatusObject(status, isTransitioning),
 	};
 };
 

--- a/packages/next-safe-action/src/hooks.types.ts
+++ b/packages/next-safe-action/src/hooks.types.ts
@@ -43,7 +43,7 @@ export type HookSafeStateActionFn<ServerError, S extends StandardSchemaV1 | unde
 /**
  * Type of the action status returned by `useAction`, `useOptimisticAction` and `useStateAction` hooks.
  */
-export type HookActionStatus = "idle" | "executing" | "transitioning" | "hasSucceeded" | "hasErrored" | "hasNavigated";
+export type HookActionStatus = "idle" | "executing" | "hasSucceeded" | "hasErrored" | "hasNavigated";
 
 /**
  * Type of the shorthand status object returned by `useAction`, `useOptimisticAction` and `useStateAction` hooks.

--- a/packages/next-safe-action/src/stateful-hooks.ts
+++ b/packages/next-safe-action/src/stateful-hooks.ts
@@ -30,7 +30,6 @@ export const useStateAction = <ServerError, S extends StandardSchemaV1 | undefin
 	const [clientInput, setClientInput] = React.useState<InferInputOrDefault<S, void>>();
 	const status = getActionStatus<ServerError, S, CVE, Data>({
 		isExecuting,
-		isTransitioning,
 		result: result ?? {},
 		isIdle,
 		// HACK: This is a workaround to avoid the status being "hasNavigated" when the action is executed.
@@ -71,6 +70,6 @@ export const useStateAction = <ServerError, S extends StandardSchemaV1 | undefin
 		input: clientInput as InferInputOrDefault<S, undefined>,
 		result,
 		status,
-		...getActionShorthandStatusObject(status),
+		...getActionShorthandStatusObject(status, isTransitioning),
 	};
 };


### PR DESCRIPTION
# Proposed changes

1.  **`hooks-utils.ts`**: Removed  `isTransitioning`  from  `getActionStatus`  parameters and logic. Updated  `getActionShorthandStatusObject`  to accept  `isTransitioning`  as a separate parameter for computing the  `isTransitioning`  and  `isPending`  shorthand properties. Removed the empty  `"transitioning"`  case from  `useActionCallbacks`.
    
2.  **`hooks.types.ts`**: Removed  `"transitioning"`  from the  `HookActionStatus`  union type.
    
3.  **`hooks.ts`**: Updated both  `useAction`  and  `useOptimisticAction`  to pass  `isTransitioning`  separately to  `getActionShorthandStatusObject`  instead of to  `getActionStatus`.
    
4.  **`stateful-hooks.ts`**: Same update for  `useStateAction`.

## Related issue(s) or discussion(s)

re #376 

---

- [x] I read the [contributing guidelines](https://github.com/TheEdoRan/next-safe-action/blob/next/CONTRIBUTING.md) and followed them before creating this pull request.
