### PR TITLE
fix: check ActionServerValidationError before serverErrorHandled guard

### DIFF
--- a/packages/next-safe-action/src/__tests__/returnValidationErrors-in-middleware.test.ts
+++ b/packages/next-safe-action/src/__tests__/returnValidationErrors-in-middleware.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
+import assert from "node:assert";
+import { test } from "node:test";
+import { z } from "zod";
+import { createSafeActionClient, returnValidationErrors } from "..";
+
+// Simulates a domain-layer error class (e.g. a unique constraint violation).
+class FieldError extends Error {
+	constructor(
+		public readonly field: string,
+		public readonly description: string
+	) {
+		super(description);
+	}
+}
+
+// Mirrors the pattern used in apps that configure handleServerError to rethrow,
+// relying on a middleware to convert known domain errors into validation errors.
+const ac = createSafeActionClient({
+	handleServerError(e) {
+		throw e;
+	},
+});
+
+const schema = z.object({ username: z.string().min(3) });
+
+// The middleware catches known domain errors and converts them to validation
+// errors via returnValidationErrors, exactly as documented. The bug causes
+// ActionServerValidationError to escape instead of being treated as
+// validationErrors on the result.
+const actionWithErrorMiddleware = ac
+	.inputSchema(schema)
+	.use(async ({ next }) => {
+		try {
+			return await next();
+		} catch (e) {
+			if (e instanceof FieldError) {
+				return returnValidationErrors(schema, {
+					[e.field]: { _errors: [e.description] },
+				});
+			}
+			throw e;
+		}
+	})
+	.action(async ({ parsedInput }) => {
+		if (parsedInput.username === "taken") {
+			throw new FieldError("username", "Username is already taken");
+		}
+		return { ok: true };
+	});
+
+// BUG REPRO: This test demonstrates that when returnValidationErrors is called
+// from a middleware catch block (after a domain error is thrown from server
+// code and handleServerError is configured to rethrow), the resulting
+// ActionServerValidationError escapes the action builder unhandled — causing
+// an unhandled rejection on the server and an error boundary hit on the client.
+//
+// Expected: { validationErrors: { username: { _errors: ["Username is already taken"] } } }
+// Actual:   Throws "Error: Server Action server validation error(s) occurred"
+test("returnValidationErrors called from a middleware catch block returns validationErrors on the result (not a thrown error)", async () => {
+	const result = await actionWithErrorMiddleware({ username: "taken" });
+	const expected = {
+		validationErrors: {
+			username: { _errors: ["Username is already taken"] },
+		},
+	};
+	assert.deepStrictEqual(result, expected);
+});
+
+// Sanity-check: when no domain error is thrown, the action succeeds normally.
+test("action succeeds normally when no domain error is thrown", async () => {
+	const result = await actionWithErrorMiddleware({ username: "available" });
+	assert.deepStrictEqual(result, { data: { ok: true } });
+});
+
+// Sanity-check: unknown errors that the middleware does not handle are still
+// forwarded through handleServerError and, when rethrown, reject the action.
+test("unhandled errors from server code still propagate when handleServerError rethrows", async () => {
+	const actionThatThrows = ac
+		.inputSchema(schema)
+		.use(async ({ next }) => {
+			try {
+				return await next();
+			} catch (e) {
+				if (e instanceof FieldError) {
+					return returnValidationErrors(schema, {
+						[e.field]: { _errors: [e.description] },
+					});
+				}
+				throw e;
+			}
+		})
+		.action(async () => {
+			throw new Error("unexpected crash");
+		});
+	await assert.rejects(() => actionThatThrows({ username: "foo" }));
+});

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -235,12 +235,9 @@ export function actionBuilder<
 								middlewareResult.bindArgsParsedInputs = parsedBindArgsInputs;
 							}
 						} catch (e: unknown) {
-							// Only handle server errors once. If already handled, rethrow to bubble up.
-							if (serverErrorHandled) {
-								throw e;
-							}
-
 							// If error is `ActionServerValidationError`, return `validationErrors` as if schema validation would fail.
+							// This check must come before `serverErrorHandled` guard so middleware catch blocks using
+							// `returnValidationErrors` work even when `handleServerError` is configured to rethrow.
 							if (e instanceof ActionServerValidationError) {
 								const ve = e.validationErrors as ValidationErrors<IS>;
 								middlewareResult.validationErrors = await Promise.resolve(
@@ -252,6 +249,10 @@ export function actionBuilder<
 									})
 								);
 							} else {
+								// Only handle server errors once. If already handled, rethrow to bubble up.
+								if (serverErrorHandled) {
+									throw e;
+								}
 								// Mark that we're handling the server error to prevent multiple calls.
 								serverErrorHandled = true;
 


### PR DESCRIPTION
# Proposed changes

Fix `returnValidationErrors` being ignored when called from a middleware catch block with a rethrowing `handleServerError`.

## Root Cause

Commit [`3bd9c2c`](https://github.com/TheEdoRan/next-safe-action/commit/3bd9c2c1475064c786c39a48b89b62134006baa7) (released in [v8.0.6](https://github.com/TheEdoRan/next-safe-action/releases/tag/v8.0.6)) introduced a `serverErrorHandled` flag to fix [#370](https://github.com/TheEdoRan/next-safe-action/issues/370) (duplicate `handleServerError` calls when the handler rethrows). The flag was placed **before** the `instanceof ActionServerValidationError` check in the catch block:

```ts
} catch (e: unknown) {
  if (serverErrorHandled) {
    throw e; // fired too early — evicted ActionServerValidationError before it could be handled
  }
  if (e instanceof ActionServerValidationError) { ... }
  ...
}
```

The sequence that triggered the bug:

1. Server code throws a domain error (e.g. a unique-constraint `FieldError`)
2. `handleServerError` is configured to rethrow → the error propagates back up and sets `serverErrorHandled = true`
3. A middleware catch block intercepts the domain error and calls `returnValidationErrors`, which throws `ActionServerValidationError`
4. `ActionServerValidationError` travels back through the middleware chain via `frameworkErrorHandler.handleError` (which rethrows non-navigation errors)
5. The outer `try/catch` in `executeMiddlewareStack` catches it — but `serverErrorHandled` is already `true`, so the guard at the top fires **before** the `instanceof` check and rethrows `ActionServerValidationError` as an unhandled exception

On the server this appears as:
```
Error: Server Action server validation error(s) occurred
```

On the client the action throws instead of returning `{ validationErrors: ... }`, triggering an error boundary.

## Fix

Move the `ActionServerValidationError` check **before** the `serverErrorHandled` guard. `ActionServerValidationError` should always be treated as a validation result — it is never a "server error" in the `handleServerError` sense, regardless of how many times the middleware stack has already processed other errors.

```ts
} catch (e: unknown) {
  // ActionServerValidationError check must come first — always route to validationErrors,
  // even when serverErrorHandled is true (i.e. handleServerError rethrew a prior domain error).
  if (e instanceof ActionServerValidationError) {
    // ... populate middlewareResult.validationErrors
  } else {
    if (serverErrorHandled) { throw e; }
    serverErrorHandled = true;
    // ... call handleServerError
  }
}
```

### Compatibility with #370

This fix preserves the original intent of the `serverErrorHandled` flag (fix [#370](https://github.com/TheEdoRan/next-safe-action/issues/370)):

| Scenario | Behavior with this fix |
|---|---|
| **#370 — plain error rethrown by `handleServerError`** | On re-entry, error is not `ActionServerValidationError` → falls to `else` → `serverErrorHandled` is `true` → re-thrown without calling `handleServerError` again. `handleServerError` is invoked exactly once. |
| **This bug — `returnValidationErrors` in middleware after `handleServerError` rethrow** | On re-entry, error is `ActionServerValidationError` → `instanceof` check fires first → routed to `validationErrors`. `handleServerError` is not called for validation errors. |

## Related issue(s) or discussion(s)

- Closes #[408] — [BUG] returnValidationErrors called from middleware catch block throws instead of returning validationErrors
- Related to [#370](https://github.com/TheEdoRan/next-safe-action/issues/370) — the original issue that introduced the `serverErrorHandled` flag
- Related to [#392](https://github.com/TheEdoRan/next-safe-action/discussions/392) — discussion reporting `handleServerError` no longer works with `returnValidationErrors`
- Breaking commit: [`3bd9c2c`](https://github.com/TheEdoRan/next-safe-action/commit/3bd9c2c1475064c786c39a48b89b62134006baa7) (v8.0.6)
- Minimal reproduction: https://github.com/brandoncroberts/next-safe-action-return-validation-errors-in-middleware-repro (branch `8.0.1-works` shows it working on v8.0.1)

---

- [x] I read the [contributing guidelines](https://github.com/TheEdoRan/next-safe-action/blob/next/CONTRIBUTING.md) and followed them before creating this pull request.
