### PR TITLE
narrow `SafeActionResult` and hook returns into discriminated unions

### DIFF
--- a/.changeset/narrow-action-result.md
+++ b/.changeset/narrow-action-result.md
@@ -1,0 +1,38 @@
+---
+"next-safe-action": minor
+---
+
+Narrow `SafeActionResult` into a discriminated union so that checking one field narrows the others to `undefined`.
+
+Previously, `data`, `serverError`, and `validationErrors` were all independently optional on the result type, which meant TypeScript could not infer that they are mutually exclusive. Now:
+
+```ts
+const { data, serverError, validationErrors } = await myAction(input);
+
+if (data) {
+  // TypeScript knows serverError and validationErrors are undefined here
+}
+
+if (serverError) {
+  // TypeScript knows data and validationErrors are undefined here
+}
+```
+
+Destructured narrowing works end-to-end: checking any one of the three fields propagates to the other two. No hook API changes are required — `useAction().result` narrows automatically.
+
+### Runtime behavior change (compound-error precedence)
+
+To make narrowing honest, the action builder now applies a precedence rule when building the result, whereas previously it could return multiple populated fields at once in rare edge cases. The precedence is:
+
+1. `validationErrors`
+2. `serverError`
+3. `data`
+
+Two documented edge cases changed as a result:
+
+- **Middleware calling `next()` twice.** Previously the result contained both the first call's `data` AND a `serverError` describing the second call. Now the result contains only the `serverError`. Calling `next()` twice is a programmer error, and returning partial data alongside the error was confusing.
+- **Invalid bind args combined with invalid main input.** Previously the result contained both a `serverError` (wrapped bind args errors) AND `validationErrors` (main input). Now the result contains only the `validationErrors`. After the user fixes the main input and resubmits, the bind args errors will surface on the next attempt.
+
+### Breaking edge case for manual result construction
+
+If you manually construct result objects in tests or mocks with more than one mutually exclusive field set (e.g. `{ data, serverError }` simultaneously), the new discriminated union will reject them at the type level. Such objects were already unreachable at runtime and should be split into separate test cases.

--- a/.changeset/narrow-action-result.md
+++ b/.changeset/narrow-action-result.md
@@ -33,6 +33,52 @@ Two documented edge cases changed as a result:
 - **Middleware calling `next()` twice.** Previously the result contained both the first call's `data` AND a `serverError` describing the second call. Now the result contains only the `serverError`. Calling `next()` twice is a programmer error, and returning partial data alongside the error was confusing.
 - **Invalid bind args combined with invalid main input.** Previously the result contained both a `serverError` (wrapped bind args errors) AND `validationErrors` (main input). Now the result contains only the `validationErrors`. After the user fixes the main input and resubmits, the bind args errors will surface on the next attempt.
 
-### Breaking edge case for manual result construction
+### Migration guide
 
-If you manually construct result objects in tests or mocks with more than one mutually exclusive field set (e.g. `{ data, serverError }` simultaneously), the new discriminated union will reject them at the type level. Such objects were already unreachable at runtime and should be split into separate test cases.
+These are the situations to check for after upgrading. All of them are rare in practice, and the fixes are mechanical. No changes are required for the typical `useAction()` / `await myAction(input)` consumer.
+
+#### 1. Tests or mocks that assert on compound result objects
+
+If you have tests that assert on a result containing more than one populated field (e.g. `{ data, serverError }` or `{ serverError, validationErrors }` simultaneously), they will fail, both because the discriminated union rejects them at the type level and because the runtime no longer produces them.
+
+```ts
+// Before
+expect(result).toStrictEqual({
+  serverError: "Invalid bind arg",
+  validationErrors: { fieldErrors: { name: ["Required"] } },
+});
+
+// After: validation errors win, bind args error surfaces on the next attempt
+expect(result).toStrictEqual({
+  validationErrors: { fieldErrors: { name: ["Required"] } },
+});
+```
+
+If you manually constructed `SafeActionResult` values in fixtures, split them into one object per branch (idle, success, server error, validation error).
+
+#### 2. Exhaustive `switch` on `status` with a `"transitioning"` case
+
+The `"transitioning"` value has been removed from the `HookActionStatus` union. It was never actually assigned at runtime, but if you had a `case "transitioning":` in an exhaustive `switch`, TypeScript will now complain that the case is unreachable.
+
+```ts
+// Before
+switch (action.status) {
+  case "idle": /* … */ break;
+  case "executing": /* … */ break;
+  case "transitioning": /* … */ break; // unreachable, delete this case
+  case "hasSucceeded": /* … */ break;
+  case "hasErrored": /* … */ break;
+  case "hasNavigated": /* … */ break;
+}
+```
+
+The `isTransitioning` boolean on the hook return object is unchanged. If you were relying on it for React transition state, nothing needs to change.
+
+#### 3. Code that reshapes the hook return type
+
+The return types of `useAction`, `useOptimisticAction`, and `useStateAction` are now discriminated unions keyed on `status`. Reading fields directly (`action.result.data`, `action.hasSucceeded`, etc.) works exactly as before. You only need to take action if you:
+
+- Use `Pick`/`Omit`/`Partial` on `UseActionHookReturn` and expected a flat shape. These utilities now distribute over the union.
+- Build custom wrappers that manually construct a value of type `UseActionHookReturn` (e.g. a test helper). The value must match exactly one branch of the union rather than the previous flat shape.
+
+The `result` object on each branch is now narrowed — for example, on the `"hasSucceeded"` branch, `result.data` is typed as `Data` (not `Data | undefined`). This is strictly more information than before, and existing code that reads it without narrowing continues to compile.

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -62,7 +62,8 @@ jobs:
           node-version-file: ".node-version"
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run test:lib
       - run: pnpm run build:lib
+      - run: pnpm run lint:lib
+      - run: pnpm run test:lib
       - name: Publish preview packages
         run: pnpm dlx pkg-pr-new publish './packages/*' --packageManager=pnpm --commentWithSha

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -66,4 +66,4 @@ jobs:
       - run: pnpm run lint:lib
       - run: pnpm run test:lib
       - name: Publish preview packages
-        run: pnpm dlx pkg-pr-new publish './packages/*' --packageManager=pnpm --commentWithSha
+        run: pnpm dlx pkg-pr-new publish './packages/*' --no-template --packageManager=pnpm --pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,9 @@ jobs:
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
       - run: pnpm install --frozen-lockfile
+      - run: pnpm run build:lib
       - run: pnpm run lint:lib
       - run: pnpm run test:lib
-      - run: pnpm run build:lib
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -1,4 +1,36 @@
-.next
-.source
-.env
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*
 !.env.example
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/docs/content/docs/api/hooks-api.mdx
+++ b/apps/docs/content/docs/api/hooks-api.mdx
@@ -336,7 +336,6 @@ Union type representing all possible hook states:
 type HookActionStatus =
 	| "idle"           // No action executed yet (or after reset)
 	| "executing"      // Action is running on the server
-	| "transitioning"  // React transition after action completes
 	| "hasSucceeded"   // Action completed with data, no errors
 	| "hasErrored"     // Action completed with errors
 	| "hasNavigated";  // Navigation function was called

--- a/apps/docs/content/docs/api/hooks-api.mdx
+++ b/apps/docs/content/docs/api/hooks-api.mdx
@@ -90,6 +90,10 @@ const { execute, result, status, ... } = useAction(safeActionFn, callbacks?);
 	}}
 />
 
+<Callout>
+The return object is a **discriminated union** keyed on `status` and the shorthand booleans (`hasSucceeded`, `hasErrored`, etc.). Checking any discriminant narrows the `result` type. For example, when `hasSucceeded` is `true`, `result.data` is guaranteed to be `Data` (not `Data | undefined`), and `result.serverError` / `result.validationErrors` are narrowed to `undefined`. See the [Type narrowing](/docs/guides/hooks#type-narrowing) guide for details.
+</Callout>
+
 ### Example
 
 ```tsx
@@ -99,7 +103,7 @@ import { useAction } from "next-safe-action/hooks";
 import { createUser } from "./actions";
 
 export function CreateUserForm() {
-	const { execute, result, isPending, hasSucceeded } = useAction(createUser, {
+	const { execute, result, isPending, hasSucceeded, hasErrored } = useAction(createUser, {
 		onSuccess: ({ data }) => {
 			console.log("Created user:", data.id);
 		},
@@ -113,10 +117,15 @@ export function CreateUserForm() {
 			e.preventDefault();
 			execute({ name: "John", email: "john@example.com" });
 		}}>
-			{result.validationErrors?.name && <p>{result.validationErrors.name._errors[0]}</p>}
+			{/* hasErrored narrows result: data is undefined, errors may be present */}
+			{hasErrored && result.validationErrors?.name && (
+				<p>{result.validationErrors.name._errors[0]}</p>
+			)}
 			<button disabled={isPending}>
 				{isPending ? "Creating..." : "Create User"}
 			</button>
+			{/* hasSucceeded narrows result: data is guaranteed present */}
+			{hasSucceeded && <p>Created user: {result.data.id}</p>}
 		</form>
 	);
 }

--- a/apps/docs/content/docs/api/safe-action-client.mdx
+++ b/apps/docs/content/docs/api/safe-action-client.mdx
@@ -368,7 +368,7 @@ The `serverCodeFn` receives a single argument object:
 
 ## `.stateAction()`
 
-Define a stateful server action for use with the `useStateAction` hook (deprecated) or React's `useActionState`.
+Define a stateful server action for use with the `useStateAction` hook or React's `useActionState`.
 
 ```ts
 client.stateAction(serverCodeFn, utils?)

--- a/apps/docs/content/docs/api/type-utilities.mdx
+++ b/apps/docs/content/docs/api/type-utilities.mdx
@@ -180,7 +180,7 @@ import type {
 
 ### `InferUseActionHookReturn`
 
-Infer the return type of `useAction` for a given action function.
+Infer the return type of `useAction` for a given action function. The inferred type is a discriminated union keyed on `status` and shorthand booleans, so checking any discriminant narrows `result` to the matching branch.
 
 ```ts
 type InferUseActionHookReturn<T extends Function>
@@ -190,7 +190,7 @@ type InferUseActionHookReturn<T extends Function>
 
 ### `InferUseOptimisticActionHookReturn`
 
-Infer the return type of `useOptimisticAction` for a given action function and state type.
+Infer the return type of `useOptimisticAction` for a given action function and state type. Includes `optimisticState` plus the same discriminated union narrowing as `InferUseActionHookReturn`.
 
 ```ts
 type InferUseOptimisticActionHookReturn<T extends Function, State = any>
@@ -198,9 +198,9 @@ type InferUseOptimisticActionHookReturn<T extends Function, State = any>
 
 **Works with:** `SafeActionFn`
 
-### `InferUseStateActionHookReturn` (deprecated)
+### `InferUseStateActionHookReturn`
 
-Infer the return type of `useStateAction` for a given stateful action function.
+Infer the return type of `useStateAction` for a given stateful action function. Includes `formAction` plus the same discriminated union narrowing as `InferUseActionHookReturn`.
 
 ```ts
 type InferUseStateActionHookReturn<T extends Function>

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -245,6 +245,65 @@ type ServerErrorFunctionUtils<MetadataSchema> = {
 
 ---
 
+## Hook result types
+
+These types describe the `result` shape within each branch of the hook return discriminated union. They are exported from `next-safe-action/hooks`.
+
+### `NormalizeActionResult`
+
+Collapses the void-success branch of a `SafeActionResult` union. When an action returns nothing (`void`), the `{ data: void }` branch is dropped so that `result.data` is exactly `undefined` rather than `void | undefined`. Applied automatically to hook `result` and `executeAsync` return types.
+
+```ts
+type NormalizeActionResult<R> = R extends { data: infer D }
+	? [D] extends [void]
+		? Exclude<R, { data: D }>
+		: R
+	: R;
+```
+
+When `Data` is not `void`, the type passes through unchanged.
+
+---
+
+### `HookIdleResult`
+
+The result shape when no action has completed yet (idle, executing, navigated). All fields are `undefined`.
+
+```ts
+type HookIdleResult = {
+	data?: undefined;
+	serverError?: undefined;
+	validationErrors?: undefined;
+};
+```
+
+---
+
+### `HookSuccessResult`
+
+The result shape for the success branch. For void-returning actions, collapses to `HookIdleResult`.
+
+```ts
+type HookSuccessResult<Data> = [Data] extends [void]
+	? HookIdleResult
+	: { data: Data; serverError?: undefined; validationErrors?: undefined };
+```
+
+---
+
+### `HookErrorResult`
+
+The result shape for the error branch. Includes the idle shape for thrown errors (where `result` is `{}` and the error is captured internally).
+
+```ts
+type HookErrorResult<ServerError, ShapedErrors> =
+	| HookIdleResult
+	| { data?: undefined; serverError: ServerError; validationErrors?: undefined }
+	| { data?: undefined; serverError?: undefined; validationErrors: ShapedErrors };
+```
+
+---
+
 ## Validation error types
 
 ### `ValidationErrors`

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -9,32 +9,36 @@ This page documents all the TypeScript types exported by next-safe-action. Types
 
 ### `SafeActionResult`
 
-The result object returned by every action execution. Each field is optional, and the presence of fields indicates the action's outcome.
+The result object returned by every action execution. Modeled as a **discriminated union** so that at most one of `data`, `serverError`, and `validationErrors` is populated — checking one field narrows the others to `undefined`.
 
 ```ts
-type SafeActionResult<ServerError, Schema, ShapedErrors, Data> = {
-	data?: Data;
-	serverError?: ServerError;
-	validationErrors?: ShapedErrors;
-};
+type SafeActionResult<ServerError, Schema, ShapedErrors, Data> =
+	| { data?: undefined; serverError?: undefined; validationErrors?: undefined } // idle / framework navigation
+	| { data: Data; serverError?: undefined; validationErrors?: undefined }        // success
+	| { data?: undefined; serverError: ServerError; validationErrors?: undefined } // server error
+	| { data?: undefined; serverError?: undefined; validationErrors: ShapedErrors }; // validation failure
 ```
 
 <TypeTable
 	type={{
 		data: {
-			description: "The successful return value from the action's server code. Present when the action completes without errors.",
+			description: "The successful return value from the action's server code. Present only in the success branch; undefined in every other branch.",
 			type: "Data | undefined",
 		},
 		serverError: {
-			description: "Error value from handleServerError when server code throws. Default type is string.",
+			description: "Error value from handleServerError when server code throws. Default type is string. Present only in the server-error branch; undefined in every other branch.",
 			type: "ServerError | undefined",
 		},
 		validationErrors: {
-			description: "Validation errors when input doesn't match the schema or when returnValidationErrors is called. Shape depends on defaultValidationErrorsShape.",
+			description: "Validation errors when input doesn't match the schema or when returnValidationErrors is called. Shape depends on defaultValidationErrorsShape. Present only in the validation-failure branch; undefined in every other branch.",
 			type: "ShapedErrors | undefined",
 		},
 	}}
 />
+
+<Callout>
+In compound-error scenarios where the runtime could otherwise produce multiple populated fields (middleware calling `next()` twice, or invalid bind args combined with invalid main input), a fixed precedence is applied: `validationErrors` > `serverError` > `data`. See [Action result](/docs/concepts/action-result#reading-the-result) for details.
+</Callout>
 
 ---
 
@@ -90,10 +94,13 @@ type MiddlewareFn<ServerError, Metadata, Ctx, NextCtx> = (opts: {
 
 ### `MiddlewareResult`
 
-The result type returned by the `next()` function inside middleware. Extends `SafeActionResult` with execution metadata.
+The result type returned by the `next()` function inside middleware. Carries the same readable fields as `SafeActionResult` plus execution metadata (navigation kind, parsed inputs, context, success flag).
 
 ```ts
-type MiddlewareResult<ServerError, NextCtx> = SafeActionResult<ServerError, any, any, any, NextCtx> & {
+type MiddlewareResult<ServerError, NextCtx> = {
+	data?: any;
+	serverError?: ServerError;
+	validationErrors?: any;
 	navigationKind?: NavigationKind;
 	parsedInput?: unknown;
 	bindArgsParsedInputs?: unknown[];
@@ -101,6 +108,10 @@ type MiddlewareResult<ServerError, NextCtx> = SafeActionResult<ServerError, any,
 	success: boolean;
 };
 ```
+
+<Callout>
+This is intentionally a flat object rather than an intersection with `SafeActionResult`. Because `SafeActionResult` is now a discriminated union, intersecting it would prevent middleware from mutating `data`/`serverError`/`validationErrors` while the chain executes. The set of readable fields is unchanged from previous versions.
+</Callout>
 
 <TypeTable
 	type={{

--- a/apps/docs/content/docs/concepts/action-result.mdx
+++ b/apps/docs/content/docs/concepts/action-result.mdx
@@ -185,7 +185,7 @@ const { execute } = useAction(myAction, {
 See the [Type narrowing](/docs/guides/hooks#type-narrowing) section for more patterns.
 
 <Callout>
-**Precedence for edge cases.** In rare situations where the runtime could otherwise produce multiple populated fields (e.g. middleware calling `next()` twice after the action had already succeeded, or invalid bind args combined with invalid main input), next-safe-action applies a fixed precedence: `validationErrors` > `serverError` > `data`. The higher-priority state fully describes the outcome; lower-priority state is discarded. This keeps the discriminated union honest at runtime.
+**Precedence for edge cases.** In rare situations where the runtime could otherwise produce multiple populated fields (e.g. invalid bind args combined with invalid main input, or middleware that throws after `await next()` has already received a validation-error result), next-safe-action applies a fixed precedence: `validationErrors` > `serverError` > `data`. The higher-priority state fully describes the outcome; lower-priority state is discarded. This keeps the discriminated union honest at runtime. See [Error precedence](/docs/concepts/error-handling#error-precedence) for the exact behavior, including how `handleServerError` and `throwServerError` interact with this rule.
 </Callout>
 
 <Accordions>

--- a/apps/docs/content/docs/concepts/action-result.mdx
+++ b/apps/docs/content/docs/concepts/action-result.mdx
@@ -49,6 +49,10 @@ const result = await greetUser({ name: "Alice" });
 
 The `data` type is **inferred** from your server code's return type. If you define an `outputSchema`, the type comes from the schema instead.
 
+<Callout>
+If your server code doesn't return anything, `result.data` is typed as exactly `undefined` rather than `void | undefined`. The runtime never emits a separate `{ data: undefined }` for void-returning actions (it returns `{}`), and the types mirror that: the idle and void-success branches collapse into a single shape. Discriminate success for these actions by checking the absence of errors instead of truthy `data`.
+</Callout>
+
 ## `validationErrors`
 
 When the input doesn't match the schema, `validationErrors` contains the validation failures. Your server code **never runs** in this case:

--- a/apps/docs/content/docs/concepts/action-result.mdx
+++ b/apps/docs/content/docs/concepts/action-result.mdx
@@ -148,17 +148,41 @@ if (serverError) {
 }
 ```
 
-With the `useAction` hook, you get this handled via callbacks:
+### In hooks
+
+With the `useAction` hook (and `useOptimisticAction`, `useStateAction`), the return object is itself a **discriminated union keyed on `status`** and shorthand booleans. Checking any discriminant narrows `result` to the matching branch:
+
+```ts
+const action = useAction(myAction);
+
+// Status-based narrowing
+if (action.hasSucceeded) {
+	action.result.data;             // Data (guaranteed)
+	action.result.serverError;      // undefined
+	action.result.validationErrors; // undefined
+}
+
+if (action.hasErrored) {
+	action.result.data; // undefined
+	// Further narrow between error kinds:
+	if (action.result.serverError) { /* ... */ }
+	if (action.result.validationErrors) { /* ... */ }
+}
+```
+
+Lifecycle callbacks also benefit from narrowing:
 
 ```ts
 const { execute } = useAction(myAction, {
-	onSuccess: ({ data }) => { /* ... */ },
+	onSuccess: ({ data }) => { /* data is guaranteed here */ },
 	onError: ({ error }) => {
 		if (error.validationErrors) { /* ... */ }
 		if (error.serverError) { /* ... */ }
 	},
 });
 ```
+
+See the [Type narrowing](/docs/guides/hooks#type-narrowing) section for more patterns.
 
 <Callout>
 **Precedence for edge cases.** In rare situations where the runtime could otherwise produce multiple populated fields (e.g. middleware calling `next()` twice after the action had already succeeded, or invalid bind args combined with invalid main input), next-safe-action applies a fixed precedence: `validationErrors` > `serverError` > `data`. The higher-priority state fully describes the outcome; lower-priority state is discarded. This keeps the discriminated union honest at runtime.

--- a/apps/docs/content/docs/concepts/action-result.mdx
+++ b/apps/docs/content/docs/concepts/action-result.mdx
@@ -7,27 +7,27 @@ Every safe action returns a **result object**, a structured response that tells 
 
 ## Result structure
 
-The result object has three optional keys:
+The result is a **discriminated union**. At most one of `data`, `validationErrors`, or `serverError` is populated, and TypeScript enforces this at the type level — checking one field narrows the others to `undefined`:
 
 ```ts
-{
-	data?: Data;              // Your server code's return value
-	validationErrors?: VE;    // Input validation failures
-	serverError?: ServerError; // Server-side errors
-}
+type SafeActionResult<ServerError, Schema, ShapedErrors, Data> =
+	| { data?: undefined; serverError?: undefined; validationErrors?: undefined } // idle / framework navigation
+	| { data: Data; serverError?: undefined; validationErrors?: undefined }        // success
+	| { data?: undefined; serverError: ServerError; validationErrors?: undefined } // server error
+	| { data?: undefined; serverError?: undefined; validationErrors: ShapedErrors }; // validation failure
 ```
 
-Only **one** of these will be present at a time, as they're mutually exclusive outcomes:
+The four branches correspond to these outcomes:
 
 | Outcome | `data` | `validationErrors` | `serverError` |
 |---|---|---|---|
 | Success | Present | - | - |
 | Validation failure | - | Present | - |
 | Server error | - | - | Present |
-| Framework error (redirect, etc.) | - | - | - |
+| Idle / framework navigation | - | - | - |
 
 <Callout>
-Framework navigation/errors (like `redirect()` or `notFound()`) are a special case. They don't return a result at all. Instead, Next.js handles the navigation directly. See [Error Handling](/docs/concepts/error-handling) for details.
+Framework navigation/errors (like `redirect()` or `notFound()`) are a special case. They don't populate any of the three fields. On the server the error is re-thrown so Next.js can handle the navigation; on the client, the hook exposes the idle branch `{}` together with a `"hasNavigated"` status. See [Error Handling](/docs/concepts/error-handling) for details.
 </Callout>
 
 ## `data`
@@ -118,12 +118,29 @@ A typical pattern for handling all cases:
 ```ts
 const result = await myAction(input);
 
-if (result?.data) {
-	// Success: use result.data
-} else if (result?.validationErrors) {
-	// Validation failed: show errors to user
-} else if (result?.serverError) {
-	// Server error: show error message
+if (result.data) {
+	// TypeScript knows serverError and validationErrors are undefined here
+	console.log(result.data);
+} else if (result.validationErrors) {
+	// TypeScript knows data and serverError are undefined here
+	console.log(result.validationErrors);
+} else if (result.serverError) {
+	// TypeScript knows data and validationErrors are undefined here
+	console.log(result.serverError);
+}
+```
+
+Destructuring works the same way — checking any one of the three variables narrows the other two:
+
+```ts
+const { data, serverError, validationErrors } = await myAction(input);
+
+if (data) {
+	// serverError and validationErrors are `undefined`
+}
+
+if (serverError) {
+	// data and validationErrors are `undefined`
 }
 ```
 
@@ -138,6 +155,10 @@ const { execute } = useAction(myAction, {
 	},
 });
 ```
+
+<Callout>
+**Precedence for edge cases.** In rare situations where the runtime could otherwise produce multiple populated fields (e.g. middleware calling `next()` twice after the action had already succeeded, or invalid bind args combined with invalid main input), next-safe-action applies a fixed precedence: `validationErrors` > `serverError` > `data`. The higher-priority state fully describes the outcome; lower-priority state is discarded. This keeps the discriminated union honest at runtime.
+</Callout>
 
 <Accordions>
 <Accordion title="Bind args validation errors">

--- a/apps/docs/content/docs/concepts/error-handling.mdx
+++ b/apps/docs/content/docs/concepts/error-handling.mdx
@@ -164,6 +164,57 @@ const { execute } = useAction(myAction, {
 
 See [Framework Errors](/docs/advanced/framework-errors) for advanced configuration.
 
+## Error precedence
+
+The action result is a discriminated union: at most one of `data`, `serverError`, and `validationErrors` is populated at a time. In most executions only one field is ever set, but a few compound scenarios can reach the final result-building step with multiple candidates:
+
+- Invalid bind args (wrapped as a server error) combined with invalid main input (validation errors).
+- Middleware that calls `await next()`, receives a result that already contains `validationErrors`, then throws afterwards (for example, a post-validation audit/cleanup step that fails).
+
+In these cases next-safe-action applies a fixed precedence when assembling the returned result:
+
+```
+validationErrors  >  serverError  >  data
+```
+
+The winning field fully describes the outcome; the lower-priority field is dropped from the returned object. For the example above where middleware throws after receiving validation errors, the client receives only the validation errors, and the thrown server-side error is not present in the result.
+
+### What still runs for dropped server errors
+
+The precedence rule only affects what appears in the **returned result**, not whether `handleServerError` executes:
+
+1. When middleware or server code throws, `handleServerError` is invoked immediately with the thrown error, regardless of any pre-existing `validationErrors`.
+2. Only after `handleServerError` has run does the result-building step apply precedence and decide which field to keep.
+
+This means logging, telemetry, Sentry integrations, and any other side effects you configure inside `handleServerError` always fire for thrown errors, even when the eventual result carries `validationErrors` instead of `serverError`. Treat `handleServerError` as the authoritative place for server-side observability; the returned result is the client-facing summary, not a full event log.
+
+### Interaction with `throwServerError`
+
+The `throwServerError` action-level flag is only consulted when no `validationErrors` are present. If the compound case produces both, the validation errors take precedence and `throwServerError` does not fire:
+
+```ts
+export const myAction = actionClient
+	.inputSchema(schema)
+	.use(async ({ next }) => {
+		const result = await next();
+		if (result.validationErrors) {
+			// This throw is caught, passed to `handleServerError`,
+			// and its return value is assigned to `middlewareResult.serverError`
+			// but the returned result still surfaces `validationErrors`.
+			throw new Error("audit cleanup failed");
+		}
+		return result;
+	})
+	.action(
+		async () => {
+			// ...
+		},
+		{ throwServerError: true } // NOT re-thrown in the compound case above
+	);
+```
+
+If you need to guarantee that an operational failure propagates even in compound cases, raise it from `handleServerError` yourself (for example by logging and then rethrowing in paths you want to hard-fail), or gate the post-`next()` side effects on `result.validationErrors === undefined` so they don't run when validation has already failed.
+
 ## Error handling summary
 
 | Error type | How it's produced | Where it appears | Safe for users? |

--- a/apps/docs/content/docs/guides/executing-actions.mdx
+++ b/apps/docs/content/docs/guides/executing-actions.mdx
@@ -41,7 +41,7 @@ export default function Page() {
 	const handleClick = async () => {
 		const result = await greetUser({ name: "Alice" });
 
-		if (result?.data) {
+		if (result.data) {
 			alert(result.data.greeting);
 		}
 	};
@@ -92,7 +92,7 @@ export default function Page() {
 		<form action={dispatch}>
 			<input name="name" defaultValue="Alice" />
 			<button type="submit">Greet</button>
-			{result?.data && <p>{result.data.greeting}</p>}
+			{result.data && <p>{result.data.greeting}</p>}
 		</form>
 	);
 }

--- a/apps/docs/content/docs/guides/form-actions.mdx
+++ b/apps/docs/content/docs/guides/form-actions.mdx
@@ -149,7 +149,7 @@ export default function LoginForm() {
 				{isPending ? "Logging in..." : "Log in"}
 			</button>
 
-			{hasSucceeded && <p>Logged in as user {result.data?.userId}</p>}
+			{hasSucceeded && <p>Logged in as user {result.data.userId}</p>}
 			{hasErrored && result.serverError && <p>Error: {result.serverError}</p>}
 			{!isPending && (hasSucceeded || hasErrored) && (
 				<button type="button" onClick={reset}>Try again</button>

--- a/apps/docs/content/docs/guides/hooks.mdx
+++ b/apps/docs/content/docs/guides/hooks.mdx
@@ -59,6 +59,46 @@ The `status` property transitions through these states:
 
 The boolean shortcuts (`isExecuting`, `hasSucceeded`, etc.) are derived from `status` for convenience.
 
+## Type narrowing
+
+The hook return object is a **discriminated union** keyed on `status` and the shorthand booleans (`hasSucceeded`, `hasErrored`, etc.). Checking any discriminant narrows the `result` type:
+
+```tsx
+const action = useAction(myAction);
+
+// Narrowing via status
+if (action.status === "hasSucceeded") {
+	action.result.data;             // Data (guaranteed present)
+	action.result.serverError;      // undefined (narrowed away)
+	action.result.validationErrors; // undefined (narrowed away)
+}
+
+// Narrowing via shorthand booleans
+if (action.hasErrored) {
+	action.result.data; // undefined (narrowed away)
+	// Further narrow between error kinds:
+	if (action.result.serverError) {
+		action.result.validationErrors; // undefined
+	}
+}
+```
+
+Destructured narrowing works too (TypeScript 4.6+):
+
+```tsx
+const { status, result, hasSucceeded } = useAction(myAction);
+
+if (status === "hasSucceeded") {
+	result.data; // narrowed to Data
+}
+
+if (hasSucceeded) {
+	result.data; // also narrowed to Data
+}
+```
+
+This applies to all hooks: `useAction`, `useOptimisticAction`, and `useStateAction`. The `result` field itself is also a discriminated union (see [Action result](/docs/concepts/action-result)), so you get two layers of narrowing: status-level and result-level.
+
 ## `execute` vs `executeAsync`
 
 | Method | Returns | Use when |

--- a/apps/docs/content/docs/guides/hooks.mdx
+++ b/apps/docs/content/docs/guides/hooks.mdx
@@ -72,7 +72,7 @@ execute({ name: "Alice" });
 
 // Await the result: useful for sequential operations
 const result = await executeAsync({ name: "Alice" });
-if (result?.data) {
+if (result.data) {
 	await executeAsync({ name: "Bob" });
 }
 ```

--- a/apps/docs/content/docs/guides/optimistic-updates.mdx
+++ b/apps/docs/content/docs/guides/optimistic-updates.mdx
@@ -146,7 +146,7 @@ If the server action fails, `optimisticState` automatically reverts to `currentS
 |---|---|---|
 | `optimisticState` | `State` | The current optimistic state to render |
 
-All callbacks (`onSuccess`, `onError`, `onSettled`, etc.) work the same way as `useAction`.
+All callbacks (`onSuccess`, `onError`, `onSettled`, etc.) work the same way as `useAction`. The return object is also a discriminated union: checking `status` or shorthand booleans like `hasSucceeded` narrows `result` to the matching branch. See [Type narrowing](/docs/guides/hooks#type-narrowing) for details.
 
 ## What's next?
 

--- a/apps/docs/content/docs/migrations/v7-to-v8.mdx
+++ b/apps/docs/content/docs/migrations/v7-to-v8.mdx
@@ -167,12 +167,6 @@ To update your actions, you can just use the search and replace feature of your 
 </Callout>
 
 
-### 🔄 Deprecation of `useStateAction` hook
-
-The `useStateAction()` hook has been deprecated. It's always been kind of a hack to begin with, and it doesn't support progressive enhancement, since it tries to do what the `useAction()` and `useOptimisticAction()` hooks do, with JS functionality.
-
-So, from now on, the recommended way to use stateful actions is to do it with the React's built in `useActionState()` hook, as explained in [this section](/docs/recipes/form-actions#stateful-form-actions) of the documentation.
-
 ## Requirements
 
 next-safe-action version 8 requires Next.js 14 and React 18.2.0 or later to work.

--- a/apps/docs/content/docs/quick-start.mdx
+++ b/apps/docs/content/docs/quick-start.mdx
@@ -130,11 +130,13 @@ export default function Login() {
 			password: "12345678",
 		});
 
-		if (result?.data) {
+		// The result is a discriminated union, so checking one
+		// field narrows the others to `undefined`.
+		if (result.data) {
 			console.log("Welcome,", result.data.name);
-		} else if (result?.validationErrors) {
+		} else if (result.validationErrors) {
 			console.log("Validation failed:", result.validationErrors);
-		} else if (result?.serverError) {
+		} else if (result.serverError) {
 			console.log("Server error:", result.serverError);
 		}
 	};

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/playground/src/components/status-badge.tsx
+++ b/apps/playground/src/components/status-badge.tsx
@@ -7,7 +7,6 @@ const statusConfig: Record<
 > = {
 	idle: { label: "Idle", variant: "secondary" },
 	executing: { label: "Executing", variant: "default" },
-	transitioning: { label: "Transitioning", variant: "outline" },
 	hasSucceeded: { label: "Succeeded", variant: "default" },
 	hasErrored: { label: "Errored", variant: "destructive" },
 	hasNavigated: { label: "Navigated", variant: "outline" },

--- a/packages/next-safe-action/src/__tests__/bind-args-validation-errors.test.ts
+++ b/packages/next-safe-action/src/__tests__/bind-args-validation-errors.test.ts
@@ -155,7 +155,7 @@ test("action with some valid and some invalid bind args returns server error wit
 	expect(actualResult).toStrictEqual(expectedResult);
 });
 
-test("action with invalid bind args and invalid main input returns both errors", async () => {
+test("action with invalid bind args and invalid main input reports main input errors (precedence)", async () => {
 	const schema = z.object({
 		username: z.string().min(3),
 	});
@@ -174,15 +174,44 @@ test("action with invalid bind args and invalid main input returns both errors",
 	// Invalid bind arg (-1 is not positive) and invalid main input ("ab" is less than 3 chars).
 	const actualResult = await action(-1, { username: "ab" });
 
-	// Both serverError (from bind args) and validationErrors (from main input) should be present.
-	expect(actualResult).toHaveProperty("serverError");
+	// The result precedence rule (validationErrors > serverError > data) means
+	// main input validation errors take precedence over bind args errors (which
+	// are wrapped as serverError). After the user fixes the main input and
+	// resubmits, they will see the bind args errors.
+	expect(actualResult).not.toHaveProperty("serverError");
 	expect(actualResult).toHaveProperty("validationErrors");
-	expect((actualResult as any).serverError).toStrictEqual({
-		bindArgsValidationErrors: [
-			{
-				_errors: ["Too small: expected number to be >0"],
-			},
-		],
+	expect((actualResult as any).validationErrors).toHaveProperty("username");
+});
+
+test("throwServerError does not override validationErrors precedence in compound state", async () => {
+	// Regression test: when bind args validation fails (wrapped as serverError)
+	// AND main input validation fails (validationErrors) AND the action opts
+	// into `throwServerError: true`, the action must NOT throw the wrapped bind
+	// args server error. The advertised precedence (validationErrors > serverError)
+	// has to be honored in the throwing path too, otherwise users lose the
+	// actionable field errors they were trying to surface.
+	const schema = z.object({
+		username: z.string().min(3),
 	});
+
+	const bindArgsSchemas: [age: z.ZodNumber] = [z.number().positive()];
+
+	const action = uac
+		.inputSchema(schema)
+		.bindArgsSchemas(bindArgsSchemas)
+		.action(
+			async () => {
+				return { ok: true };
+			},
+			{ throwServerError: true }
+		);
+
+	// Invalid bind arg AND invalid main input, with throwServerError enabled.
+	const actualResult = await action(-1, { username: "ab" });
+
+	// The action should NOT throw — it should return a result with validationErrors.
+	expect(actualResult).not.toHaveProperty("serverError");
+	expect(actualResult).not.toHaveProperty("data");
+	expect(actualResult).toHaveProperty("validationErrors");
 	expect((actualResult as any).validationErrors).toHaveProperty("username");
 });

--- a/packages/next-safe-action/src/__tests__/middleware-edge-cases.test.ts
+++ b/packages/next-safe-action/src/__tests__/middleware-edge-cases.test.ts
@@ -36,10 +36,10 @@ test("middleware that calls next twice throws an error", async () => {
 
 	const actualResult = await action();
 
-	// Calling next() twice is guarded. The first call succeeds (data is set),
-	// then the second call triggers a server error.
+	// Calling next() twice is guarded. The second call triggers a server error,
+	// which takes precedence over the first call's data per the result precedence
+	// rule (validationErrors > serverError > data).
 	expect(actualResult).toStrictEqual({
-		data: { ok: true },
 		serverError: "next() called multiple times in middleware. Each middleware must call next() at most once.",
 	});
 });

--- a/packages/next-safe-action/src/__tests__/middleware-edge-cases.test.ts
+++ b/packages/next-safe-action/src/__tests__/middleware-edge-cases.test.ts
@@ -437,6 +437,77 @@ test("use() middleware calling next() normally still works (chain completion gua
 	expect(order).toStrictEqual(["before", "action", "after"]);
 });
 
+// ─── Result invariant: at most one populated discriminator field ─────
+//
+// The discriminated-union contract guarantees that `SafeActionResult` has at
+// most one populated field among `{ data, serverError, validationErrors }`.
+// These tests walk scenarios that could internally produce a compound state
+// (next() twice, failed bind args + failed main input, error thrown mid-chain)
+// and assert the invariant holds across all of them. Without these, a future
+// edit to `buildResultAndRunCallbacks` in `action-builder.ts` could quietly
+// re-admit compound results and no single-scenario test would catch it.
+
+test("result invariant: at most one of data/serverError/validationErrors is ever populated", async () => {
+	const schema = z.object({ name: z.string().min(3) });
+	const bindSchemas: [n: z.ZodNumber] = [z.number().positive()];
+
+	const scenarios: Array<{ label: string; run: () => Promise<unknown> }> = [
+		{
+			label: "happy path",
+			run: () => ac.inputSchema(schema).action(async () => ({ ok: true }))({ name: "alice" }),
+		},
+		{
+			label: "validation error",
+			run: () => ac.inputSchema(schema).action(async () => ({ ok: true }))({ name: "ab" }),
+		},
+		{
+			label: "server error from thrown middleware",
+			run: () =>
+				ac
+					.use(async () => {
+						throw new Error("boom");
+					})
+					.action(async () => ({ ok: true }))(),
+		},
+		{
+			label: "next() twice after success",
+			run: () =>
+				ac
+					.use(async ({ next }) => {
+						await next();
+						return next();
+					})
+					.action(async () => ({ ok: true }))(),
+		},
+		{
+			label: "invalid bind args + invalid main input",
+			run: () =>
+				ac
+					.inputSchema(schema)
+					.bindArgsSchemas(bindSchemas)
+					.action(async () => ({ ok: true }))(-1, { name: "ab" }),
+		},
+		{
+			label: "idle (middleware returns early without next())",
+			run: () =>
+				ac
+					// @ts-expect-error - intentional short-circuit to exercise idle output
+					.use(async () => {
+						// no next()
+					})
+					.action(async () => ({ ok: true }))(),
+		},
+	];
+
+	for (const { label, run } of scenarios) {
+		const result = (await run()) as Record<string, unknown>;
+		const populated = (["data", "serverError", "validationErrors"] as const).filter(
+			(k) => typeof result[k] !== "undefined"
+		);
+		expect(populated.length, `${label} produced compound result: ${JSON.stringify(result)}`).toBeLessThanOrEqual(1);
+	}
+});
+
 test("stored next() from use() that was called once cannot be called again after chain completion", async () => {
 	let storedNext: (() => Promise<unknown>) | null = null;
 

--- a/packages/next-safe-action/src/__tests__/navigation-errors.test.ts
+++ b/packages/next-safe-action/src/__tests__/navigation-errors.test.ts
@@ -204,3 +204,44 @@ test("multiple redirects in sequence each throw navigation error", async () => {
 
 	expect(redirectCount).toBe(2);
 });
+
+test("navigation error discards any pre-populated result (onSettled receives empty result)", async () => {
+	// Regression guard for the precedence at `buildResultAndRunCallbacks` in
+	// `action-builder.ts`: a framework navigation error at any stage short-circuits
+	// the result to `{}` before any data accumulated during the run can leak into
+	// `onSettled`. We construct a compound state where the inner action succeeds
+	// (populating `middlewareResult.data`) and then an outer middleware throws a
+	// redirect during post-processing — onSettled must still see `result: {}`.
+	let onSettledResult: unknown;
+	let innerData: unknown;
+
+	const action = ac
+		.use(async ({ next }) => {
+			const res = await next();
+			// Inner action succeeded; its data is observable here, confirming the
+			// setup is valid — the inner `next()` did populate `data`.
+			innerData = (res as { data?: unknown }).data;
+			redirect("/after-success");
+		})
+		.action(
+			async () => {
+				return { inner: "ran to completion" };
+			},
+			{
+				onSettled: async ({ result }) => {
+					onSettledResult = result;
+				},
+			}
+		);
+
+	await action().catch((e) => {
+		if (!FrameworkErrorHandler.isNavigationError(e)) {
+			throw e;
+		}
+	});
+
+	// Inner action data DID exist mid-flight — middleware saw it.
+	expect(innerData).toEqual({ inner: "ran to completion" });
+	// But onSettled received the idle shape, not the partial success.
+	expect(onSettledResult).toStrictEqual({});
+});

--- a/packages/next-safe-action/src/__tests__/stateful-hooks.test.tsx
+++ b/packages/next-safe-action/src/__tests__/stateful-hooks.test.tsx
@@ -398,6 +398,61 @@ describe("useStateAction reset", () => {
 		expect(result.current.result.data).toEqual({ message: "seed" });
 	});
 
+	test("reset restores initResult with serverError (regression for non-data seeds)", async () => {
+		// The data-seed reset case is already covered above. This test pins the
+		// same contract for an initResult that only carries a `serverError`,
+		// catching a hypothetical regression where the restore path special-cases
+		// the `data` field instead of preserving the full seed object.
+		const action = createMockStateAction(async () => ({ data: { message: "after-execute" } }));
+		const initResult: TestResult = { serverError: "seeded error" };
+		const { result } = renderHook(() => useStateAction(action, { initResult }));
+
+		expect(result.current.result.serverError).toBe("seeded error");
+
+		act(() => {
+			result.current.execute(undefined);
+		});
+		await flushHookTimers();
+
+		expect(result.current.status).toBe("hasSucceeded");
+		expect(result.current.result.data).toEqual({ message: "after-execute" });
+
+		act(() => {
+			result.current.reset();
+		});
+
+		expect(result.current.status).toBe("idle");
+		expect(result.current.isIdle).toBe(true);
+		expect(result.current.result.serverError).toBe("seeded error");
+		expect(result.current.result.data).toBeUndefined();
+	});
+
+	test("reset restores initResult with validationErrors (regression for non-data seeds)", async () => {
+		const action = createMockStateAction(async () => ({ data: { message: "after-execute" } }));
+		const seededValidationErrors = { _errors: ["seeded validation failure"] } as any;
+		const initResult: TestResult = { validationErrors: seededValidationErrors };
+		const { result } = renderHook(() => useStateAction(action, { initResult }));
+
+		expect(result.current.result.validationErrors).toEqual(seededValidationErrors);
+
+		act(() => {
+			result.current.execute(undefined);
+		});
+		await flushHookTimers();
+
+		expect(result.current.status).toBe("hasSucceeded");
+		expect(result.current.result.data).toEqual({ message: "after-execute" });
+
+		act(() => {
+			result.current.reset();
+		});
+
+		expect(result.current.status).toBe("idle");
+		expect(result.current.isIdle).toBe(true);
+		expect(result.current.result.validationErrors).toEqual(seededValidationErrors);
+		expect(result.current.result.data).toBeUndefined();
+	});
+
 	test("reset overrides prevResult for next execution", async () => {
 		let receivedPrevResult: TestResult | undefined;
 		const action = createMockStateAction(async (prevResult) => {

--- a/packages/next-safe-action/src/__tests__/stateful-hooks.test.tsx
+++ b/packages/next-safe-action/src/__tests__/stateful-hooks.test.tsx
@@ -205,6 +205,54 @@ describe("useStateAction basic lifecycle", () => {
 
 		expect(result.current.result.data).toEqual({ message: "initial" });
 	});
+
+	test("initResult with data is exposed as result on idle mount", () => {
+		const action = createMockStateAction();
+		const { result } = renderHook(() =>
+			useStateAction(action, {
+				initResult: { data: { message: "initial" } },
+			})
+		);
+
+		expect(result.current.status).toBe("idle");
+		expect(result.current.isIdle).toBe(true);
+		expect(result.current.result.data).toEqual({ message: "initial" });
+	});
+
+	test("initResult with serverError is exposed as result on idle mount", () => {
+		const action = createMockStateAction();
+		const { result } = renderHook(() =>
+			useStateAction(action, {
+				initResult: { serverError: "Seeded error" },
+			})
+		);
+
+		expect(result.current.status).toBe("idle");
+		expect(result.current.isIdle).toBe(true);
+		expect(result.current.result.serverError).toBe("Seeded error");
+	});
+
+	test("initResult with validationErrors is exposed as result on idle mount", () => {
+		const action = createMockStateAction();
+		const { result } = renderHook(() =>
+			useStateAction(action, {
+				initResult: { validationErrors: { _errors: ["Seeded validation failure"] } as any },
+			})
+		);
+
+		expect(result.current.status).toBe("idle");
+		expect(result.current.isIdle).toBe(true);
+		expect(result.current.result.validationErrors).toEqual({ _errors: ["Seeded validation failure"] });
+	});
+
+	test("empty initResult starts idle with empty result", () => {
+		const action = createMockStateAction();
+		const { result } = renderHook(() => useStateAction(action, { initResult: {} }));
+
+		expect(result.current.status).toBe("idle");
+		expect(result.current.isIdle).toBe(true);
+		expect(result.current.result).toEqual({});
+	});
 });
 
 // ─── prevResult ─────────────────────────────────────────────────────────────
@@ -325,6 +373,29 @@ describe("useStateAction reset", () => {
 		expect(result.current.isIdle).toBe(true);
 		expect(result.current.result).toEqual({});
 		expect(result.current.input).toBeUndefined();
+	});
+
+	test("reset restores visible result to initResult", async () => {
+		const action = createMockStateAction(async () => ({ data: { message: "after-execute" } }));
+		const initResult: TestResult = { data: { message: "seed" } };
+		const { result } = renderHook(() => useStateAction(action, { initResult }));
+
+		expect(result.current.result.data).toEqual({ message: "seed" });
+
+		act(() => {
+			result.current.execute(undefined);
+		});
+		await flushHookTimers();
+
+		expect(result.current.result.data).toEqual({ message: "after-execute" });
+
+		act(() => {
+			result.current.reset();
+		});
+
+		expect(result.current.status).toBe("idle");
+		expect(result.current.isIdle).toBe(true);
+		expect(result.current.result.data).toEqual({ message: "seed" });
 	});
 
 	test("reset overrides prevResult for next execution", async () => {

--- a/packages/next-safe-action/src/__tests__/types/action-result.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/action-result.test-d.ts
@@ -78,3 +78,39 @@ test("SafeActionResult has correct shape", () => {
 	expectTypeOf<Result["serverError"]>().toEqualTypeOf<string | undefined>();
 	expectTypeOf<Result["validationErrors"]>().toEqualTypeOf<undefined>();
 });
+
+test("SafeActionResult narrows on truthy data", () => {
+	const schema = z.object({ name: z.string() });
+	type Result = SafeActionResult<string, typeof schema, ValidationErrors<typeof schema>, { id: string }>;
+	const r = {} as Result;
+
+	if (r.data) {
+		expectTypeOf(r.data).toEqualTypeOf<{ id: string }>();
+		expectTypeOf(r.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(r.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("SafeActionResult narrows on truthy serverError", () => {
+	const schema = z.object({ name: z.string() });
+	type Result = SafeActionResult<string, typeof schema, ValidationErrors<typeof schema>, { id: string }>;
+	const r = {} as Result;
+
+	if (r.serverError) {
+		expectTypeOf(r.data).toEqualTypeOf<undefined>();
+		expectTypeOf(r.serverError).toEqualTypeOf<string>();
+		expectTypeOf(r.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("SafeActionResult narrows on truthy validationErrors", () => {
+	const schema = z.object({ name: z.string() });
+	type Result = SafeActionResult<string, typeof schema, ValidationErrors<typeof schema>, { id: string }>;
+	const r = {} as Result;
+
+	if (r.validationErrors) {
+		expectTypeOf(r.data).toEqualTypeOf<undefined>();
+		expectTypeOf(r.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(r.validationErrors).toEqualTypeOf<ValidationErrors<typeof schema>>();
+	}
+});

--- a/packages/next-safe-action/src/__tests__/types/hooks-return.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/hooks-return.test-d.ts
@@ -1,3 +1,7 @@
+// Verifies that hook return types form a discriminated union keyed on `status`
+// and shorthand booleans (`hasSucceeded`, `hasErrored`, etc.). Checking any
+// discriminant narrows the `result` type accordingly.
+
 import { expectTypeOf, test } from "vitest";
 import { z } from "zod";
 import type {
@@ -8,14 +12,23 @@ import type {
 	InferUseOptimisticActionHookReturn,
 	InferUseStateActionHookReturn,
 	HookActionStatus,
+	HookIdleResult,
+	HookSuccessResult,
+	HookErrorResult,
 } from "../../hooks.types";
 import type { SafeActionFn, SafeStateActionFn } from "../../index.types";
 import type { ValidationErrors } from "../../validation-errors.types";
 
-test("UseActionHookReturn has execute, executeAsync, input, result, reset, status", () => {
-	const schema = z.object({ name: z.string() });
-	type Return = UseActionHookReturn<string, typeof schema, ValidationErrors<typeof schema>, { id: string }>;
+const schema = z.object({ name: z.string() });
 
+type Data = { id: string };
+type ServerError = string;
+type Shape = ValidationErrors<typeof schema>;
+type Return = UseActionHookReturn<ServerError, typeof schema, Shape, Data>;
+
+// ─── Core properties ────────────────────────────────────────────────────────
+
+test("UseActionHookReturn has execute, executeAsync, input, result, reset, status", () => {
 	// Core properties exist
 	expectTypeOf<Return["execute"]>().not.toBeAny();
 	expectTypeOf<Return["executeAsync"]>().not.toBeAny();
@@ -26,49 +39,38 @@ test("UseActionHookReturn has execute, executeAsync, input, result, reset, statu
 });
 
 test("UseActionHookReturn execute accepts correct input type", () => {
-	const schema = z.object({ name: z.string() });
-	type Return = UseActionHookReturn<string, typeof schema, ValidationErrors<typeof schema>, { id: string }>;
-
 	// execute takes schema input
 	expectTypeOf<Return["execute"]>().toEqualTypeOf<(input: { name: string }) => void>();
 });
 
 test("UseActionHookReturn result.data matches action return type", () => {
-	const schema = z.object({ name: z.string() });
-	type Return = UseActionHookReturn<string, typeof schema, ValidationErrors<typeof schema>, { id: string }>;
-
-	expectTypeOf<Return["result"]["data"]>().toEqualTypeOf<{ id: string } | undefined>();
-	expectTypeOf<Return["result"]["serverError"]>().toEqualTypeOf<string | undefined>();
+	expectTypeOf<Return["result"]["data"]>().toEqualTypeOf<Data | undefined>();
+	expectTypeOf<Return["result"]["serverError"]>().toEqualTypeOf<ServerError | undefined>();
 });
 
 test("UseActionHookReturn result narrows on truthy data", () => {
-	const schema = z.object({ name: z.string() });
-	type Return = UseActionHookReturn<string, typeof schema, ValidationErrors<typeof schema>, { id: string }>;
 	const ret = {} as Return;
 
 	if (ret.result.data) {
-		expectTypeOf(ret.result.data).toEqualTypeOf<{ id: string }>();
+		expectTypeOf(ret.result.data).toEqualTypeOf<Data>();
 		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
 		expectTypeOf(ret.result.validationErrors).toEqualTypeOf<undefined>();
 	}
 });
 
 test("UseActionHookReturn result destructuring narrows together", () => {
-	const schema = z.object({ name: z.string() });
-	type Return = UseActionHookReturn<string, typeof schema, ValidationErrors<typeof schema>, { id: string }>;
 	const ret = {} as Return;
 	const { data, serverError, validationErrors } = ret.result;
 
 	if (data) {
-		expectTypeOf(data).toEqualTypeOf<{ id: string }>();
+		expectTypeOf(data).toEqualTypeOf<Data>();
 		expectTypeOf(serverError).toEqualTypeOf<undefined>();
 		expectTypeOf(validationErrors).toEqualTypeOf<undefined>();
 	}
 });
 
 test("UseActionHookReturn has shorthand status booleans", () => {
-	type Return = UseActionHookReturn<string, undefined, undefined, void>;
-
+	// Across the whole union, each boolean is `true | false` = `boolean`
 	expectTypeOf<Return["isIdle"]>().toEqualTypeOf<boolean>();
 	expectTypeOf<Return["isExecuting"]>().toEqualTypeOf<boolean>();
 	expectTypeOf<Return["isTransitioning"]>().toEqualTypeOf<boolean>();
@@ -82,9 +84,178 @@ test("void-returning action: UseActionHookReturn result.data is exactly `undefin
 	// When the action returns nothing, `result.data` should narrow to `undefined`
 	// rather than `void | undefined`. This mirrors the `await action()` behavior
 	// at the hook layer so users see the same type regardless of how they invoke.
-	type Return = UseActionHookReturn<string, undefined, undefined, void>;
-	expectTypeOf<Return["result"]["data"]>().toEqualTypeOf<undefined>();
+	type VoidReturn = UseActionHookReturn<string, undefined, undefined, void>;
+	expectTypeOf<VoidReturn["result"]["data"]>().toEqualTypeOf<undefined>();
 });
+
+// ─── Status-based narrowing (discriminated union) ───────────────────────────
+
+test("status === 'hasSucceeded' narrows result to success branch", () => {
+	const ret = {} as Return;
+
+	if (ret.status === "hasSucceeded") {
+		expectTypeOf(ret.result.data).toEqualTypeOf<Data>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.validationErrors).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.hasSucceeded).toEqualTypeOf<true>();
+		expectTypeOf(ret.hasErrored).toEqualTypeOf<false>();
+		expectTypeOf(ret.isIdle).toEqualTypeOf<false>();
+		expectTypeOf(ret.isExecuting).toEqualTypeOf<false>();
+	}
+});
+
+test("status === 'hasErrored' narrows result to error branches (data is always undefined)", () => {
+	const ret = {} as Return;
+
+	if (ret.status === "hasErrored") {
+		expectTypeOf(ret.result.data).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.hasErrored).toEqualTypeOf<true>();
+		expectTypeOf(ret.hasSucceeded).toEqualTypeOf<false>();
+		expectTypeOf(ret.isIdle).toEqualTypeOf<false>();
+		expectTypeOf(ret.isExecuting).toEqualTypeOf<false>();
+	}
+});
+
+test("status === 'hasErrored' allows further narrowing on serverError", () => {
+	const ret = {} as Return;
+
+	if (ret.status === "hasErrored") {
+		if (ret.result.serverError) {
+			expectTypeOf(ret.result.serverError).toEqualTypeOf<ServerError>();
+			expectTypeOf(ret.result.validationErrors).toEqualTypeOf<undefined>();
+		}
+	}
+});
+
+test("status === 'hasErrored' allows further narrowing on validationErrors", () => {
+	const ret = {} as Return;
+
+	if (ret.status === "hasErrored") {
+		if (ret.result.validationErrors) {
+			expectTypeOf(ret.result.validationErrors).toEqualTypeOf<Shape>();
+			expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		}
+	}
+});
+
+test("status === 'idle' narrows result to idle (empty) shape", () => {
+	const ret = {} as Return;
+
+	if (ret.status === "idle") {
+		expectTypeOf(ret.result.data).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.validationErrors).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.isIdle).toEqualTypeOf<true>();
+		expectTypeOf(ret.isExecuting).toEqualTypeOf<false>();
+		expectTypeOf(ret.hasSucceeded).toEqualTypeOf<false>();
+	}
+});
+
+test("status === 'executing' narrows booleans to literal types", () => {
+	const ret = {} as Return;
+
+	if (ret.status === "executing") {
+		expectTypeOf(ret.isExecuting).toEqualTypeOf<true>();
+		expectTypeOf(ret.isPending).toEqualTypeOf<true>();
+		expectTypeOf(ret.isIdle).toEqualTypeOf<false>();
+		expectTypeOf(ret.hasSucceeded).toEqualTypeOf<false>();
+		expectTypeOf(ret.hasErrored).toEqualTypeOf<false>();
+	}
+});
+
+test("status === 'hasNavigated' narrows result to idle (empty) shape", () => {
+	const ret = {} as Return;
+
+	if (ret.status === "hasNavigated") {
+		expectTypeOf(ret.result.data).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.hasNavigated).toEqualTypeOf<true>();
+		expectTypeOf(ret.hasSucceeded).toEqualTypeOf<false>();
+		expectTypeOf(ret.hasErrored).toEqualTypeOf<false>();
+	}
+});
+
+// ─── Shorthand boolean narrowing ────────────────────────────────────────────
+
+test("hasSucceeded (shorthand) narrows result to success branch", () => {
+	const ret = {} as Return;
+
+	if (ret.hasSucceeded) {
+		expectTypeOf(ret.result.data).toEqualTypeOf<Data>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.validationErrors).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.status).toEqualTypeOf<"hasSucceeded">();
+	}
+});
+
+test("hasErrored (shorthand) narrows result, data is always undefined", () => {
+	const ret = {} as Return;
+
+	if (ret.hasErrored) {
+		expectTypeOf(ret.result.data).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.status).toEqualTypeOf<"hasErrored">();
+	}
+});
+
+test("isIdle (shorthand) narrows to idle state", () => {
+	const ret = {} as Return;
+
+	if (ret.isIdle) {
+		expectTypeOf(ret.result.data).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.status).toEqualTypeOf<"idle">();
+	}
+});
+
+test("isExecuting (shorthand) narrows to executing state", () => {
+	const ret = {} as Return;
+
+	if (ret.isExecuting) {
+		expectTypeOf(ret.status).toEqualTypeOf<"executing">();
+		expectTypeOf(ret.isPending).toEqualTypeOf<true>();
+	}
+});
+
+// ─── Destructured narrowing (TS 4.6+ discriminated union destructuring) ─────
+
+test("destructured status narrows result", () => {
+	const { status, result } = {} as Return;
+
+	if (status === "hasSucceeded") {
+		expectTypeOf(result.data).toEqualTypeOf<Data>();
+		expectTypeOf(result.serverError).toEqualTypeOf<undefined>();
+	}
+});
+
+test("destructured hasSucceeded narrows result", () => {
+	const { hasSucceeded, result } = {} as Return;
+
+	if (hasSucceeded) {
+		expectTypeOf(result.data).toEqualTypeOf<Data>();
+		expectTypeOf(result.serverError).toEqualTypeOf<undefined>();
+	}
+});
+
+test("destructured hasErrored narrows result", () => {
+	const { hasErrored, result } = {} as Return;
+
+	if (hasErrored) {
+		expectTypeOf(result.data).toEqualTypeOf<undefined>();
+	}
+});
+
+// ─── Void-returning action narrowing ────────────────────────────────────────
+
+test("void action: hasSucceeded narrows result.data to undefined", () => {
+	type VoidReturn = UseActionHookReturn<string, undefined, undefined, void>;
+	const ret = {} as VoidReturn;
+
+	if (ret.hasSucceeded) {
+		// Void actions never produce a data field, so success result.data stays undefined
+		expectTypeOf(ret.result.data).toEqualTypeOf<undefined>();
+	}
+});
+
+// ─── UseOptimisticActionHookReturn ──────────────────────────────────────────
 
 test("UseOptimisticActionHookReturn includes optimisticState", () => {
 	type Return = UseOptimisticActionHookReturn<string, undefined, undefined, void, { count: number }>;
@@ -94,6 +265,20 @@ test("UseOptimisticActionHookReturn includes optimisticState", () => {
 	expectTypeOf<Return["execute"]>().not.toBeAny();
 	expectTypeOf<Return["status"]>().toEqualTypeOf<HookActionStatus>();
 });
+
+test("UseOptimisticActionHookReturn preserves discriminated union narrowing", () => {
+	type OptReturn = UseOptimisticActionHookReturn<ServerError, typeof schema, Shape, Data, { count: number }>;
+	const ret = {} as OptReturn;
+
+	if (ret.hasSucceeded) {
+		expectTypeOf(ret.result.data).toEqualTypeOf<Data>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.optimisticState).toEqualTypeOf<{ count: number }>();
+		expectTypeOf(ret.status).toEqualTypeOf<"hasSucceeded">();
+	}
+});
+
+// ─── UseStateActionHookReturn ───────────────────────────────────────────────
 
 test("UseStateActionHookReturn has execute, executeAsync, reset, and formAction", () => {
 	type Return = UseStateActionHookReturn<string, undefined, undefined, void>;
@@ -109,35 +294,23 @@ test("UseStateActionHookReturn has execute, executeAsync, reset, and formAction"
 	expectTypeOf<HasFormAction>().toEqualTypeOf<true>();
 });
 
-test("InferUseActionHookReturn extracts return type from SafeActionFn", () => {
-	const schema = z.object({ name: z.string() });
-	type ActionFn = SafeActionFn<string, typeof schema, [], ValidationErrors<typeof schema>, { id: string }>;
-	type Return = InferUseActionHookReturn<ActionFn>;
+test("UseStateActionHookReturn preserves discriminated union narrowing", () => {
+	type StateReturn = UseStateActionHookReturn<ServerError, typeof schema, Shape, Data>;
+	const ret = {} as StateReturn;
 
-	expectTypeOf<Return["result"]["data"]>().toEqualTypeOf<{ id: string } | undefined>();
-	expectTypeOf<Return>().not.toBeAny();
-});
+	if (ret.hasSucceeded) {
+		expectTypeOf(ret.result.data).toEqualTypeOf<Data>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.status).toEqualTypeOf<"hasSucceeded">();
+	}
 
-test("InferUseOptimisticActionHookReturn extracts return type", () => {
-	const schema = z.object({ name: z.string() });
-	type ActionFn = SafeActionFn<string, typeof schema, [], ValidationErrors<typeof schema>, { id: string }>;
-	type Return = InferUseOptimisticActionHookReturn<ActionFn, { count: number }>;
-
-	expectTypeOf<Return["optimisticState"]>().toEqualTypeOf<{ count: number }>();
-	expectTypeOf<Return>().not.toBeAny();
-});
-
-test("InferUseStateActionHookReturn extracts from SafeStateActionFn", () => {
-	const schema = z.object({ name: z.string() });
-	type StateActionFn = SafeStateActionFn<string, typeof schema, [], ValidationErrors<typeof schema>, { id: string }>;
-	type Return = InferUseStateActionHookReturn<StateActionFn>;
-
-	expectTypeOf<Return["result"]["data"]>().toEqualTypeOf<{ id: string } | undefined>();
-	expectTypeOf<Return>().not.toBeAny();
+	if (ret.hasErrored) {
+		expectTypeOf(ret.result.data).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.status).toEqualTypeOf<"hasErrored">();
+	}
 });
 
 test("UseStateActionHookReturn has all UseActionHookReturn properties plus formAction", () => {
-	const schema = z.object({ name: z.string() });
 	type Return = UseStateActionHookReturn<string, typeof schema, ValidationErrors<typeof schema>, { id: string }>;
 
 	// Has all the same properties as UseActionHookReturn
@@ -158,4 +331,64 @@ test("UseStateActionHookReturn has all UseActionHookReturn properties plus formA
 
 	// result.data matches action return type
 	expectTypeOf<Return["result"]["data"]>().toEqualTypeOf<{ id: string } | undefined>();
+});
+
+// ─── Infer utility types ────────────────────────────────────────────────────
+
+test("InferUseActionHookReturn extracts return type from SafeActionFn", () => {
+	type ActionFn = SafeActionFn<string, typeof schema, [], ValidationErrors<typeof schema>, { id: string }>;
+	type Return = InferUseActionHookReturn<ActionFn>;
+
+	expectTypeOf<Return["result"]["data"]>().toEqualTypeOf<{ id: string } | undefined>();
+	expectTypeOf<Return>().not.toBeAny();
+});
+
+test("InferUseOptimisticActionHookReturn extracts return type", () => {
+	type ActionFn = SafeActionFn<string, typeof schema, [], ValidationErrors<typeof schema>, { id: string }>;
+	type Return = InferUseOptimisticActionHookReturn<ActionFn, { count: number }>;
+
+	expectTypeOf<Return["optimisticState"]>().toEqualTypeOf<{ count: number }>();
+	expectTypeOf<Return>().not.toBeAny();
+});
+
+test("InferUseStateActionHookReturn extracts from SafeStateActionFn", () => {
+	type StateActionFn = SafeStateActionFn<string, typeof schema, [], ValidationErrors<typeof schema>, { id: string }>;
+	type Return = InferUseStateActionHookReturn<StateActionFn>;
+
+	expectTypeOf<Return["result"]["data"]>().toEqualTypeOf<{ id: string } | undefined>();
+	expectTypeOf<Return>().not.toBeAny();
+});
+
+// ─── Result helper types ────────────────────────────────────────────────────
+
+test("HookIdleResult has all fields optional/undefined", () => {
+	expectTypeOf<HookIdleResult["data"]>().toEqualTypeOf<undefined>();
+	expectTypeOf<HookIdleResult["serverError"]>().toEqualTypeOf<undefined>();
+	expectTypeOf<HookIdleResult["validationErrors"]>().toEqualTypeOf<undefined>();
+});
+
+test("HookSuccessResult: non-void Data produces data: Data", () => {
+	type Result = HookSuccessResult<{ id: string }>;
+	expectTypeOf<Result["data"]>().toEqualTypeOf<{ id: string }>();
+	expectTypeOf<Result["serverError"]>().toEqualTypeOf<undefined>();
+});
+
+test("HookSuccessResult: void Data collapses to HookIdleResult", () => {
+	type Result = HookSuccessResult<void>;
+	expectTypeOf<Result>().toEqualTypeOf<HookIdleResult>();
+});
+
+test("HookErrorResult allows narrowing on serverError or validationErrors", () => {
+	type Result = HookErrorResult<string, Shape>;
+	const r = {} as Result;
+
+	if (r.serverError) {
+		expectTypeOf(r.serverError).toEqualTypeOf<string>();
+		expectTypeOf(r.validationErrors).toEqualTypeOf<undefined>();
+	}
+
+	if (r.validationErrors) {
+		expectTypeOf(r.validationErrors).toEqualTypeOf<Shape>();
+		expectTypeOf(r.serverError).toEqualTypeOf<undefined>();
+	}
 });

--- a/packages/next-safe-action/src/__tests__/types/hooks-return.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/hooks-return.test-d.ts
@@ -333,6 +333,54 @@ test("UseStateActionHookReturn has all UseActionHookReturn properties plus formA
 	expectTypeOf<Return["result"]["data"]>().toEqualTypeOf<{ id: string } | undefined>();
 });
 
+test("UseStateActionHookReturn idle branch is narrowed by InitR generic", () => {
+	type SeededInit = { data: { id: number }; serverError?: undefined; validationErrors?: undefined };
+	type Return = UseStateActionHookReturn<
+		string,
+		typeof schema,
+		ValidationErrors<typeof schema>,
+		{ id: number },
+		SeededInit
+	>;
+	const ret = {} as Return;
+
+	if (ret.status === "idle") {
+		// Idle branch's result is narrowed to the seeded shape, not the empty HookIdleResult
+		expectTypeOf(ret.result.data).toEqualTypeOf<{ id: number }>();
+	}
+});
+
+test("UseStateActionHookReturn idle branch preserves all idle keys when InitR is a partial seed", () => {
+	// InitR inferred from a literal omits serverError/validationErrors keys; the public idle
+	// type must still expose them as `undefined` so destructuring code stays sound.
+	type SeededInit = { data: { id: number } };
+	type Return = UseStateActionHookReturn<
+		string,
+		typeof schema,
+		ValidationErrors<typeof schema>,
+		{ id: number },
+		SeededInit
+	>;
+	const ret = {} as Return;
+
+	if (ret.status === "idle") {
+		expectTypeOf(ret.result.data).toEqualTypeOf<{ id: number }>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("UseStateActionHookReturn idle branch defaults to HookIdleResult when InitR is omitted", () => {
+	type Return = UseStateActionHookReturn<string, typeof schema, ValidationErrors<typeof schema>, { id: number }>;
+	const ret = {} as Return;
+
+	if (ret.status === "idle") {
+		expectTypeOf(ret.result.data).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
 // ─── Infer utility types ────────────────────────────────────────────────────
 
 test("InferUseActionHookReturn extracts return type from SafeActionFn", () => {

--- a/packages/next-safe-action/src/__tests__/types/hooks-return.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/hooks-return.test-d.ts
@@ -41,6 +41,31 @@ test("UseActionHookReturn result.data matches action return type", () => {
 	expectTypeOf<Return["result"]["serverError"]>().toEqualTypeOf<string | undefined>();
 });
 
+test("UseActionHookReturn result narrows on truthy data", () => {
+	const schema = z.object({ name: z.string() });
+	type Return = UseActionHookReturn<string, typeof schema, ValidationErrors<typeof schema>, { id: string }>;
+	const ret = {} as Return;
+
+	if (ret.result.data) {
+		expectTypeOf(ret.result.data).toEqualTypeOf<{ id: string }>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("UseActionHookReturn result destructuring narrows together", () => {
+	const schema = z.object({ name: z.string() });
+	type Return = UseActionHookReturn<string, typeof schema, ValidationErrors<typeof schema>, { id: string }>;
+	const ret = {} as Return;
+	const { data, serverError, validationErrors } = ret.result;
+
+	if (data) {
+		expectTypeOf(data).toEqualTypeOf<{ id: string }>();
+		expectTypeOf(serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
 test("UseActionHookReturn has shorthand status booleans", () => {
 	type Return = UseActionHookReturn<string, undefined, undefined, void>;
 

--- a/packages/next-safe-action/src/__tests__/types/hooks-return.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/hooks-return.test-d.ts
@@ -12,6 +12,7 @@ import type {
 	InferUseOptimisticActionHookReturn,
 	InferUseStateActionHookReturn,
 	HookActionStatus,
+	HookCallbacks,
 	HookIdleResult,
 	HookSuccessResult,
 	HookErrorResult,
@@ -86,6 +87,93 @@ test("void-returning action: UseActionHookReturn result.data is exactly `undefin
 	// at the hook layer so users see the same type regardless of how they invoke.
 	type VoidReturn = UseActionHookReturn<string, undefined, undefined, void>;
 	expectTypeOf<VoidReturn["result"]["data"]>().toEqualTypeOf<undefined>();
+});
+
+// ─── Hook callback narrowing ────────────────────────────────────────────────
+//
+// `useAction`, `useOptimisticAction`, and `useStateAction` all forward lifecycle
+// callbacks (`onSuccess`, `onError`, `onSettled`, `onNavigation`) from the
+// `HookCallbacks` type defined in `hooks.types.ts`. These tests pin the
+// discriminated-union narrowing and auxiliary fields on those callback args,
+// because the hook layer adds `thrownError` to `onError` that the server-side
+// `ActionCallbacks` does not expose.
+
+test("onSettled hook callback's result parameter narrows on truthy data", () => {
+	type CB = NonNullable<HookCallbacks<ServerError, typeof schema, Shape, Data>["onSettled"]>;
+	type ResultArg = Parameters<CB>[0]["result"];
+
+	const settled = {} as ResultArg;
+	if (settled.data) {
+		expectTypeOf(settled.data).toEqualTypeOf<Data>();
+		expectTypeOf(settled.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(settled.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("onSettled hook callback's result parameter narrows on truthy serverError", () => {
+	type CB = NonNullable<HookCallbacks<ServerError, typeof schema, Shape, Data>["onSettled"]>;
+	type ResultArg = Parameters<CB>[0]["result"];
+
+	const settled = {} as ResultArg;
+	if (settled.serverError) {
+		expectTypeOf(settled.serverError).toEqualTypeOf<ServerError>();
+		expectTypeOf(settled.data).toEqualTypeOf<undefined>();
+		expectTypeOf(settled.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("onSettled hook callback's result parameter narrows on truthy validationErrors", () => {
+	type CB = NonNullable<HookCallbacks<ServerError, typeof schema, Shape, Data>["onSettled"]>;
+	type ResultArg = Parameters<CB>[0]["result"];
+
+	const settled = {} as ResultArg;
+	if (settled.validationErrors) {
+		expectTypeOf(settled.validationErrors).toEqualTypeOf<Shape>();
+		expectTypeOf(settled.data).toEqualTypeOf<undefined>();
+		expectTypeOf(settled.serverError).toEqualTypeOf<undefined>();
+	}
+});
+
+test("onSettled hook callback receives optional navigationKind", () => {
+	type CB = NonNullable<HookCallbacks<ServerError, typeof schema, Shape, Data>["onSettled"]>;
+	type NavArg = Parameters<CB>[0]["navigationKind"];
+	// `navigationKind` is optional because non-navigation outcomes omit it.
+	// The "other" member is emitted by `FrameworkErrorHandler.getNavigationKind`
+	// as a fallback for unrecognized digests, so it must stay in the union.
+	expectTypeOf<NavArg>().toEqualTypeOf<
+		"redirect" | "notFound" | "forbidden" | "unauthorized" | "other" | undefined
+	>();
+});
+
+test("onError hook callback's error parameter exposes thrownError: Error | undefined", () => {
+	// The hook-level `onError` intersects the server error result with
+	// `{ thrownError?: Error }` so hook consumers can surface exceptions that
+	// never became a typed `serverError` (e.g. render-phase throws, mid-transition
+	// failures). The field is optional — present only when an exception was caught.
+	type CB = NonNullable<HookCallbacks<ServerError, typeof schema, Shape, Data>["onError"]>;
+	type ErrorArg = Parameters<CB>[0]["error"];
+
+	expectTypeOf<ErrorArg["thrownError"]>().toEqualTypeOf<Error | undefined>();
+});
+
+test("onError hook callback's error parameter still narrows on serverError/validationErrors", () => {
+	// Intersecting `{ thrownError?: Error }` with the discriminated union must
+	// NOT collapse the narrowing behavior of the underlying branches.
+	//
+	// Note: the sibling-to-`undefined` narrowing (proven for `ActionCallbacks`
+	// in `result-narrowing.test-d.ts`) does NOT carry through cleanly after the
+	// `Prettify` + intersection, so here we only assert positive narrowing on
+	// the checked field. That matches how consumers actually use `onError`.
+	type CB = NonNullable<HookCallbacks<ServerError, typeof schema, Shape, Data>["onError"]>;
+	type ErrorArg = Parameters<CB>[0]["error"];
+
+	const err = {} as ErrorArg;
+	if (err.serverError) {
+		expectTypeOf(err.serverError).toEqualTypeOf<ServerError>();
+	}
+	if (err.validationErrors) {
+		expectTypeOf(err.validationErrors).toEqualTypeOf<Shape>();
+	}
 });
 
 // ─── Status-based narrowing (discriminated union) ───────────────────────────
@@ -381,6 +469,65 @@ test("UseStateActionHookReturn idle branch defaults to HookIdleResult when InitR
 	}
 });
 
+test("UseStateActionHookReturn idle branch narrowed by serverError-only InitR", () => {
+	// Users sometimes seed `initResult` with a fresh-state server error (e.g. from
+	// a server component that already failed) and rely on the idle result exposing
+	// that error literally rather than `string | undefined`.
+	type SeededInit = { serverError: "seeded" };
+	type Return = UseStateActionHookReturn<
+		string,
+		typeof schema,
+		ValidationErrors<typeof schema>,
+		{ id: number },
+		SeededInit
+	>;
+	const ret = {} as Return;
+
+	if (ret.status === "idle") {
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<"seeded">();
+		expectTypeOf(ret.result.data).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("UseStateActionHookReturn idle branch narrowed by validationErrors-only InitR", () => {
+	type SeededShape = { name: { _errors: string[] } };
+	type SeededInit = { validationErrors: SeededShape };
+	type Return = UseStateActionHookReturn<
+		string,
+		typeof schema,
+		ValidationErrors<typeof schema>,
+		{ id: number },
+		SeededInit
+	>;
+	const ret = {} as Return;
+
+	if (ret.status === "idle") {
+		expectTypeOf(ret.result.validationErrors).toEqualTypeOf<SeededShape>();
+		expectTypeOf(ret.result.data).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+	}
+});
+
+test("UseStateActionHookReturn idle branch passes-through non-idle branches when InitR is set", () => {
+	// Non-idle branches are unaffected by InitR. If the action succeeds after the
+	// seeded idle result, the success branch's `result.data` is the real Data
+	// type, not the seed.
+	type SeededInit = { data: { id: 42 } };
+	type Return = UseStateActionHookReturn<
+		string,
+		typeof schema,
+		ValidationErrors<typeof schema>,
+		{ id: number },
+		SeededInit
+	>;
+	const ret = {} as Return;
+
+	if (ret.status === "hasSucceeded") {
+		expectTypeOf(ret.result.data).toEqualTypeOf<{ id: number }>();
+	}
+});
+
 // ─── Infer utility types ────────────────────────────────────────────────────
 
 test("InferUseActionHookReturn extracts return type from SafeActionFn", () => {
@@ -405,6 +552,116 @@ test("InferUseStateActionHookReturn extracts from SafeStateActionFn", () => {
 
 	expectTypeOf<Return["result"]["data"]>().toEqualTypeOf<{ id: string } | undefined>();
 	expectTypeOf<Return>().not.toBeAny();
+});
+
+// ─── Infer*HookReturn preserves discriminated union narrowing ───────────────
+//
+// The `Infer*` utilities are a public API surface (exported from `hooks.types`).
+// Consumers rely on them producing a usable discriminated union — not just a
+// flat bag where `result.data` happens to have the right leaf type. These tests
+// pin the narrowing behavior on inferred returns, catching any regression that
+// collapses the union during inference.
+
+test("InferUseActionHookReturn preserves narrowing on hasSucceeded", () => {
+	type ActionFn = SafeActionFn<string, typeof schema, [], Shape, { id: string }>;
+	type Return = InferUseActionHookReturn<ActionFn>;
+	const ret = {} as Return;
+
+	if (ret.hasSucceeded) {
+		expectTypeOf(ret.result.data).toEqualTypeOf<{ id: string }>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.result.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("InferUseOptimisticActionHookReturn preserves narrowing on hasSucceeded", () => {
+	type ActionFn = SafeActionFn<string, typeof schema, [], Shape, { id: string }>;
+	type Return = InferUseOptimisticActionHookReturn<ActionFn, { count: number }>;
+	const ret = {} as Return;
+
+	if (ret.hasSucceeded) {
+		expectTypeOf(ret.result.data).toEqualTypeOf<{ id: string }>();
+		expectTypeOf(ret.optimisticState).toEqualTypeOf<{ count: number }>();
+		expectTypeOf(ret.status).toEqualTypeOf<"hasSucceeded">();
+	}
+});
+
+test("InferUseStateActionHookReturn preserves narrowing on hasSucceeded", () => {
+	type StateActionFn = SafeStateActionFn<string, typeof schema, [], Shape, { id: string }>;
+	type Return = InferUseStateActionHookReturn<StateActionFn>;
+	const ret = {} as Return;
+
+	if (ret.hasSucceeded) {
+		expectTypeOf(ret.result.data).toEqualTypeOf<{ id: string }>();
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(ret.status).toEqualTypeOf<"hasSucceeded">();
+	}
+});
+
+test("InferUseActionHookReturn preserves narrowing on hasErrored status", () => {
+	type ActionFn = SafeActionFn<string, typeof schema, [], Shape, { id: string }>;
+	type Return = InferUseActionHookReturn<ActionFn>;
+	const ret = {} as Return;
+
+	if (ret.status === "hasErrored" && ret.result.serverError) {
+		expectTypeOf(ret.result.serverError).toEqualTypeOf<string>();
+		expectTypeOf(ret.result.data).toEqualTypeOf<undefined>();
+	}
+});
+
+// ─── Destructured narrowing on state and optimistic hook returns ────────────
+//
+// TypeScript 4.6+ narrows destructured fields of a discriminated union. The
+// base test at `UseActionHookReturn` already pins this behavior, but the state
+// and optimistic hook types are built via different type constructions
+// (intersection + Omit over a mapped conditional for state, plain intersection
+// for optimistic). A regression in either construction would break destructured
+// narrowing without breaking the base test — worth a separate assertion.
+
+test("destructuring UseStateActionHookReturn narrows on status", () => {
+	const { status, result } = {} as UseStateActionHookReturn<ServerError, typeof schema, Shape, Data>;
+
+	if (status === "hasSucceeded") {
+		expectTypeOf(result.data).toEqualTypeOf<Data>();
+		expectTypeOf(result.serverError).toEqualTypeOf<undefined>();
+	}
+});
+
+test("destructuring UseStateActionHookReturn narrows on hasErrored shorthand", () => {
+	const { hasErrored, result } = {} as UseStateActionHookReturn<ServerError, typeof schema, Shape, Data>;
+
+	if (hasErrored) {
+		expectTypeOf(result.data).toEqualTypeOf<undefined>();
+	}
+});
+
+test("destructuring UseOptimisticActionHookReturn narrows on status", () => {
+	const { status, result, optimisticState } = {} as UseOptimisticActionHookReturn<
+		ServerError,
+		typeof schema,
+		Shape,
+		Data,
+		{ count: number }
+	>;
+
+	if (status === "hasSucceeded") {
+		expectTypeOf(result.data).toEqualTypeOf<Data>();
+		expectTypeOf(optimisticState).toEqualTypeOf<{ count: number }>();
+	}
+});
+
+test("destructuring UseOptimisticActionHookReturn narrows on hasSucceeded shorthand", () => {
+	const { hasSucceeded, result } = {} as UseOptimisticActionHookReturn<
+		ServerError,
+		typeof schema,
+		Shape,
+		Data,
+		{ count: number }
+	>;
+
+	if (hasSucceeded) {
+		expectTypeOf(result.data).toEqualTypeOf<Data>();
+	}
 });
 
 // ─── Result helper types ────────────────────────────────────────────────────

--- a/packages/next-safe-action/src/__tests__/types/hooks-return.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/hooks-return.test-d.ts
@@ -78,6 +78,14 @@ test("UseActionHookReturn has shorthand status booleans", () => {
 	expectTypeOf<Return["hasNavigated"]>().toEqualTypeOf<boolean>();
 });
 
+test("void-returning action: UseActionHookReturn result.data is exactly `undefined`", () => {
+	// When the action returns nothing, `result.data` should narrow to `undefined`
+	// rather than `void | undefined`. This mirrors the `await action()` behavior
+	// at the hook layer so users see the same type regardless of how they invoke.
+	type Return = UseActionHookReturn<string, undefined, undefined, void>;
+	expectTypeOf<Return["result"]["data"]>().toEqualTypeOf<undefined>();
+});
+
 test("UseOptimisticActionHookReturn includes optimisticState", () => {
 	type Return = UseOptimisticActionHookReturn<string, undefined, undefined, void, { count: number }>;
 

--- a/packages/next-safe-action/src/__tests__/types/middleware-ctx.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/middleware-ctx.test-d.ts
@@ -175,3 +175,48 @@ test("MiddlewareFn type parameters are correctly constrained", () => {
 
 	expectTypeOf(mw).not.toBeAny();
 });
+
+// ─── MiddlewareResult flat shape (post-refactor regression guard) ──────────
+//
+// `MiddlewareResult` used to be `SafeActionResult<SE, any, any, any, NextCtx> & { success; ... }`.
+// When `SafeActionResult` became a discriminated union, that intersection would
+// have forced middleware authors to narrow before reading any field of `await next()`.
+// The type was flattened to a plain object with independently-optional result
+// fields. These tests pin that shape so a future refactor doesn't silently
+// re-introduce the discriminated union there.
+
+test("MiddlewareResult exposes result fields as independently optional", () => {
+	type MR = MiddlewareResult<string, { userId: string }>;
+	const mr = {} as MR;
+
+	// All three result fields are independently readable — no narrowing needed.
+	expectTypeOf(mr.data).toEqualTypeOf<any>();
+	expectTypeOf(mr.serverError).toEqualTypeOf<string | undefined>();
+	expectTypeOf(mr.validationErrors).toEqualTypeOf<any>();
+	expectTypeOf(mr.success).toEqualTypeOf<boolean>();
+	expectTypeOf(mr.parsedInput).toEqualTypeOf<unknown>();
+	expectTypeOf(mr.bindArgsParsedInputs).toEqualTypeOf<unknown[] | undefined>();
+});
+
+test("MiddlewareResult admits all result fields populated simultaneously", () => {
+	type MR = MiddlewareResult<string, object>;
+	// If MiddlewareResult were still a discriminated union, this compound
+	// literal would be rejected. The flat shape must accept it so middleware
+	// authors can construct partial results (e.g., stubbing in tests).
+	const _flat: MR = {
+		data: { id: "x" },
+		serverError: "oops",
+		validationErrors: { name: { _errors: ["required"] } },
+		success: false,
+	};
+	void _flat;
+});
+
+test("MiddlewareResult<SE, A> and MiddlewareResult<SE, B> are mutually assignable (NextCtx is phantom)", () => {
+	type A = MiddlewareResult<string, { a: 1 }>;
+	type B = MiddlewareResult<string, { b: 2 }>;
+	const a = {} as A;
+	const b: B = a;
+	const _aFromB: A = b;
+	void _aFromB;
+});

--- a/packages/next-safe-action/src/__tests__/types/result-narrowing.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/result-narrowing.test-d.ts
@@ -164,23 +164,27 @@ test("the canonical user DX case: await action() destructured + narrowed", async
 	}
 });
 
-// ─── Void-returning actions: idle and success branches collapse ────────────
+// ─── Void-returning actions ───────────────────────────────────────────────
 //
 // When `Data = void`, the runtime never emits `{ data: undefined }` separately
 // from the idle `{}` — see `buildResultAndRunCallbacks` in action-builder.ts,
-// which only sets `data` when `middlewareResult.data !== undefined`. Public-
-// facing types apply `NormalizeActionResult` at the boundary so that user
-// code sees `data: undefined` rather than `data: void | undefined`.
+// which only sets `data` when `middlewareResult.data !== undefined`.
+//
+// `NormalizeActionResult` is NOT applied at the `SafeActionFn` return level
+// because doing so would cause TypeScript to eagerly expand the discriminated
+// union during `.bind()`, breaking generic inference for hooks. Instead,
+// normalization is applied at the hook boundary (e.g. `UseActionHookReturn`),
+// where users see `data: undefined` for void actions. At the direct `await`
+// level, `data` is `void | undefined`.
 
 // Use a schema so ShapedErrors is a real type (not `undefined`), which keeps
-// the error branches distinguishable for narrowing tests. Build the result
-// type from the user-facing `SafeActionFn` so it goes through the collapse.
+// the error branches distinguishable for narrowing tests.
 type VoidFn = SafeActionFn<string, typeof schema, [], Shape, void>;
 type VoidResult = InferSafeActionFnResult<VoidFn>;
 
-test("void-returning action: r.data is exactly `undefined`", () => {
+test("void-returning action: r.data is `void | undefined` at direct await level", () => {
 	const r = {} as VoidResult;
-	expectTypeOf<typeof r.data>().toEqualTypeOf<undefined>();
+	expectTypeOf<typeof r.data>().toEqualTypeOf<void | undefined>();
 });
 
 test("void-returning action: error branches still narrow and leave data as undefined", () => {
@@ -204,16 +208,16 @@ test("void-returning action: runtime `{}` still assigns to the result type", () 
 	void _idle;
 });
 
-test("void-returning action inferred from serverCodeFn has r.data = undefined", async () => {
+test("void-returning action inferred from serverCodeFn has r.data = void | undefined", async () => {
 	// End-to-end: define an action that returns nothing and verify the
-	// awaited result's `data` field is exactly `undefined`.
+	// awaited result's `data` field type at the direct await level.
 	const ac = createSafeActionClient();
 	const action = ac.action(async () => {
 		return;
 	});
 
 	const r = await action();
-	expectTypeOf<typeof r.data>().toEqualTypeOf<undefined>();
+	expectTypeOf<typeof r.data>().toEqualTypeOf<void | undefined>();
 });
 
 test("data-returning action still narrows unchanged (regression guard)", async () => {

--- a/packages/next-safe-action/src/__tests__/types/result-narrowing.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/result-narrowing.test-d.ts
@@ -1,0 +1,164 @@
+// Verifies that `SafeActionResult` narrows correctly across its four branches
+// (idle, success, server error, validation error). These tests pin down the
+// contract users depend on when destructuring an action result and checking
+// one field to know the state of the others.
+
+import { expectTypeOf, test } from "vitest";
+import { z } from "zod";
+import type { ActionCallbacks, InferSafeActionFnResult, SafeActionFn, SafeActionResult } from "../../index.types";
+import type { ValidationErrors } from "../../validation-errors.types";
+
+const schema = z.object({ name: z.string().min(1) });
+
+type Data = { id: string };
+type ServerError = string;
+type Shape = ValidationErrors<typeof schema>;
+type Result = SafeActionResult<ServerError, typeof schema, Shape, Data>;
+
+// ─── Direct access narrowing ────────────────────────────────────────────────
+
+test("unguarded read preserves X | undefined for each field", () => {
+	const r = {} as Result;
+	expectTypeOf(r.data).toEqualTypeOf<Data | undefined>();
+	expectTypeOf(r.serverError).toEqualTypeOf<ServerError | undefined>();
+	expectTypeOf(r.validationErrors).toEqualTypeOf<Shape | undefined>();
+});
+
+test("if (result.data) narrows sibling fields to undefined", () => {
+	const r = {} as Result;
+	if (r.data) {
+		expectTypeOf(r.data).toEqualTypeOf<Data>();
+		expectTypeOf(r.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(r.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("if (result.serverError) narrows siblings to undefined", () => {
+	const r = {} as Result;
+	if (r.serverError) {
+		expectTypeOf(r.data).toEqualTypeOf<undefined>();
+		expectTypeOf(r.serverError).toEqualTypeOf<ServerError>();
+		expectTypeOf(r.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("if (result.validationErrors) narrows siblings to undefined", () => {
+	const r = {} as Result;
+	if (r.validationErrors) {
+		expectTypeOf(r.data).toEqualTypeOf<undefined>();
+		expectTypeOf(r.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(r.validationErrors).toEqualTypeOf<Shape>();
+	}
+});
+
+// ─── Destructured narrowing (the primary user DX case) ─────────────────────
+
+test("destructured fields narrow together on if (data)", () => {
+	const { data, serverError, validationErrors } = {} as Result;
+
+	if (data) {
+		expectTypeOf(data).toEqualTypeOf<Data>();
+		expectTypeOf(serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("destructured fields narrow together on if (serverError)", () => {
+	const { data, serverError, validationErrors } = {} as Result;
+
+	if (serverError) {
+		expectTypeOf(data).toEqualTypeOf<undefined>();
+		expectTypeOf(serverError).toEqualTypeOf<ServerError>();
+		expectTypeOf(validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("destructured fields narrow together on if (validationErrors)", () => {
+	const { data, serverError, validationErrors } = {} as Result;
+
+	if (validationErrors) {
+		expectTypeOf(data).toEqualTypeOf<undefined>();
+		expectTypeOf(serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(validationErrors).toEqualTypeOf<Shape>();
+	}
+});
+
+// ─── Idle branch and fresh-object assignability ────────────────────────────
+
+test("empty object assigns to Result (idle branch)", () => {
+	// The successful compilation IS the assertion — `{}` must be assignable
+	// to Result so that `useAction`'s `useState<Result>({})` initializer works.
+	const _idle: Result = {};
+	void _idle;
+});
+
+test("fresh object literals assign for each branch", () => {
+	// Each line's successful compilation is the test. If any assignment
+	// stopped matching a branch of the discriminated union, TypeScript would
+	// reject it here.
+	const _idle: Result = {};
+	const _success: Result = { data: { id: "x" } };
+	const _serverErr: Result = { serverError: "oops" };
+	const _validationErr: Result = { validationErrors: { name: { _errors: ["required"] } } as Shape };
+	void _idle;
+	void _success;
+	void _serverErr;
+	void _validationErr;
+});
+
+// ─── onError callback receives the full union (no cast needed) ─────────────
+
+test("onError callback's error parameter accepts the full result union", () => {
+	type CB = NonNullable<ActionCallbacks<ServerError, undefined, object, typeof schema, [], Shape, Data>["onError"]>;
+
+	type ErrorArg = Parameters<CB>[0]["error"];
+
+	// The onError callback omits `data` from the result type. Under the new
+	// discriminated union, `Omit<Result, "data">` distributes over the union
+	// and still narrows on truthy error fields.
+	const err = {} as ErrorArg;
+	if (err.serverError) {
+		expectTypeOf(err.serverError).toEqualTypeOf<ServerError>();
+	}
+	if (err.validationErrors) {
+		expectTypeOf(err.validationErrors).toEqualTypeOf<Shape>();
+	}
+});
+
+// ─── Generic inference via InferSafeActionFnResult ─────────────────────────
+
+test("InferSafeActionFnResult preserves narrowing on extracted result", () => {
+	type Fn = SafeActionFn<ServerError, typeof schema, [], Shape, Data>;
+	type R = InferSafeActionFnResult<Fn>;
+
+	const r = {} as R;
+	if (r.data) {
+		expectTypeOf(r.data).toEqualTypeOf<Data>();
+		expectTypeOf(r.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(r.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+// ─── Real-world usage shape ────────────────────────────────────────────────
+
+test("the canonical user DX case: await action() destructured + narrowed", async () => {
+	// Build a realistic action function signature.
+	type Fn = SafeActionFn<string, typeof schema, [], Shape, Data>;
+	const action = (async () => ({}) as Result) as unknown as Fn;
+
+	const { data, serverError, validationErrors } = await action({ name: "x" });
+
+	if (data) {
+		expectTypeOf(data).toEqualTypeOf<Data>();
+		expectTypeOf(serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(validationErrors).toEqualTypeOf<undefined>();
+	} else if (serverError) {
+		expectTypeOf(data).toEqualTypeOf<undefined>();
+		expectTypeOf(serverError).toEqualTypeOf<string>();
+		expectTypeOf(validationErrors).toEqualTypeOf<undefined>();
+	} else if (validationErrors) {
+		expectTypeOf(data).toEqualTypeOf<undefined>();
+		expectTypeOf(serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(validationErrors).toEqualTypeOf<Shape>();
+	}
+});

--- a/packages/next-safe-action/src/__tests__/types/result-narrowing.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/result-narrowing.test-d.ts
@@ -5,6 +5,7 @@
 
 import { expectTypeOf, test } from "vitest";
 import { z } from "zod";
+import { createSafeActionClient } from "../..";
 import type { ActionCallbacks, InferSafeActionFnResult, SafeActionFn, SafeActionResult } from "../../index.types";
 import type { ValidationErrors } from "../../validation-errors.types";
 
@@ -161,4 +162,84 @@ test("the canonical user DX case: await action() destructured + narrowed", async
 		expectTypeOf(serverError).toEqualTypeOf<undefined>();
 		expectTypeOf(validationErrors).toEqualTypeOf<Shape>();
 	}
+});
+
+// ─── Void-returning actions: idle and success branches collapse ────────────
+//
+// When `Data = void`, the runtime never emits `{ data: undefined }` separately
+// from the idle `{}` — see `buildResultAndRunCallbacks` in action-builder.ts,
+// which only sets `data` when `middlewareResult.data !== undefined`. Public-
+// facing types apply `NormalizeActionResult` at the boundary so that user
+// code sees `data: undefined` rather than `data: void | undefined`.
+
+// Use a schema so ShapedErrors is a real type (not `undefined`), which keeps
+// the error branches distinguishable for narrowing tests. Build the result
+// type from the user-facing `SafeActionFn` so it goes through the collapse.
+type VoidFn = SafeActionFn<string, typeof schema, [], Shape, void>;
+type VoidResult = InferSafeActionFnResult<VoidFn>;
+
+test("void-returning action: r.data is exactly `undefined`", () => {
+	const r = {} as VoidResult;
+	expectTypeOf<typeof r.data>().toEqualTypeOf<undefined>();
+});
+
+test("void-returning action: error branches still narrow and leave data as undefined", () => {
+	const r = {} as VoidResult;
+	if (r.serverError) {
+		expectTypeOf(r.serverError).toEqualTypeOf<string>();
+		expectTypeOf(r.data).toEqualTypeOf<undefined>();
+		expectTypeOf(r.validationErrors).toEqualTypeOf<undefined>();
+	}
+	if (r.validationErrors) {
+		expectTypeOf(r.validationErrors).toEqualTypeOf<Shape>();
+		expectTypeOf(r.data).toEqualTypeOf<undefined>();
+		expectTypeOf(r.serverError).toEqualTypeOf<undefined>();
+	}
+});
+
+test("void-returning action: runtime `{}` still assigns to the result type", () => {
+	// The successful compilation IS the assertion — the runtime idle/success
+	// shape must remain compatible with the type.
+	const _idle: VoidResult = {};
+	void _idle;
+});
+
+test("void-returning action inferred from serverCodeFn has r.data = undefined", async () => {
+	// End-to-end: define an action that returns nothing and verify the
+	// awaited result's `data` field is exactly `undefined`.
+	const ac = createSafeActionClient();
+	const action = ac.action(async () => {
+		return;
+	});
+
+	const r = await action();
+	expectTypeOf<typeof r.data>().toEqualTypeOf<undefined>();
+});
+
+test("data-returning action still narrows unchanged (regression guard)", async () => {
+	const ac = createSafeActionClient();
+	const action = ac.action(async () => {
+		return { id: "abc" };
+	});
+
+	const r = await action();
+	expectTypeOf<typeof r.data>().toEqualTypeOf<{ id: string } | undefined>();
+	if (r.data) {
+		expectTypeOf(r.data).toEqualTypeOf<{ id: string }>();
+	}
+});
+
+test("default SafeActionResult (Data=unknown) keeps the success branch", () => {
+	// If `Data` is the default `unknown`, the success branch must NOT collapse.
+	// `r.data` stays reachable as `unknown` rather than being forced to `undefined`.
+	type R = SafeActionResult<string, typeof schema>;
+	const r = {} as R;
+	// Before any narrowing, r.data unions the success branch's `unknown` with the
+	// other branches' `undefined`, which simplifies to `unknown`.
+	expectTypeOf<typeof r.data>().toEqualTypeOf<unknown>();
+	// A fresh object with an arbitrary `data` value must still be assignable
+	// through the success branch — this fails if the success branch has been
+	// incorrectly collapsed for non-void Data.
+	const _success: R = { data: { anything: true } };
+	void _success;
 });

--- a/packages/next-safe-action/src/__tests__/types/result-narrowing.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/result-narrowing.test-d.ts
@@ -107,6 +107,41 @@ test("fresh object literals assign for each branch", () => {
 	void _validationErr;
 });
 
+// ─── Negative tests: compound literals must not assign ─────────────────────
+//
+// These tests pin the mutual exclusivity contract. Without them, a regression
+// that widens `SafeActionResult` back into a flat object (where all three fields
+// are independently optional) would silently re-admit compound literals —
+// defeating the narrowing guarantee users depend on.
+
+test("compound {data, serverError} literal is rejected", () => {
+	// @ts-expect-error — success and server error branches are mutually exclusive
+	const _bad: Result = { data: { id: "x" }, serverError: "oops" };
+	void _bad;
+});
+
+test("compound {data, validationErrors} literal is rejected", () => {
+	// @ts-expect-error — success and validation error branches are mutually exclusive
+	const _bad: Result = { data: { id: "x" }, validationErrors: { name: { _errors: ["required"] } } as Shape };
+	void _bad;
+});
+
+test("compound {serverError, validationErrors} literal is rejected", () => {
+	// @ts-expect-error — server error and validation error branches are mutually exclusive
+	const _bad: Result = { serverError: "oops", validationErrors: { name: { _errors: ["required"] } } as Shape };
+	void _bad;
+});
+
+test("all-three-fields literal is rejected", () => {
+	// @ts-expect-error — no branch of the union accepts all three fields populated
+	const _bad: Result = {
+		data: { id: "x" },
+		serverError: "oops",
+		validationErrors: { name: { _errors: ["required"] } } as Shape,
+	};
+	void _bad;
+});
+
 // ─── onError callback receives the full union (no cast needed) ─────────────
 
 test("onError callback's error parameter accepts the full result union", () => {
@@ -123,6 +158,47 @@ test("onError callback's error parameter accepts the full result union", () => {
 	}
 	if (err.validationErrors) {
 		expectTypeOf(err.validationErrors).toEqualTypeOf<Shape>();
+	}
+});
+
+// ─── onSettled callback receives the full result union ─────────────────────
+
+test("onSettled callback's result parameter narrows on truthy data", () => {
+	type CB = NonNullable<ActionCallbacks<ServerError, undefined, object, typeof schema, [], Shape, Data>["onSettled"]>;
+	type ResultArg = Parameters<CB>[0]["result"];
+
+	// `onSettled` fires after every outcome, so it receives the raw
+	// `SafeActionResult` union. Narrowing must still propagate through
+	// `Prettify<...>` to the callback consumer.
+	const settled = {} as ResultArg;
+	if (settled.data) {
+		expectTypeOf(settled.data).toEqualTypeOf<Data>();
+		expectTypeOf(settled.serverError).toEqualTypeOf<undefined>();
+		expectTypeOf(settled.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("onSettled callback's result parameter narrows on truthy serverError", () => {
+	type CB = NonNullable<ActionCallbacks<ServerError, undefined, object, typeof schema, [], Shape, Data>["onSettled"]>;
+	type ResultArg = Parameters<CB>[0]["result"];
+
+	const settled = {} as ResultArg;
+	if (settled.serverError) {
+		expectTypeOf(settled.serverError).toEqualTypeOf<ServerError>();
+		expectTypeOf(settled.data).toEqualTypeOf<undefined>();
+		expectTypeOf(settled.validationErrors).toEqualTypeOf<undefined>();
+	}
+});
+
+test("onSettled callback's result parameter narrows on truthy validationErrors", () => {
+	type CB = NonNullable<ActionCallbacks<ServerError, undefined, object, typeof schema, [], Shape, Data>["onSettled"]>;
+	type ResultArg = Parameters<CB>[0]["result"];
+
+	const settled = {} as ResultArg;
+	if (settled.validationErrors) {
+		expectTypeOf(settled.validationErrors).toEqualTypeOf<Shape>();
+		expectTypeOf(settled.data).toEqualTypeOf<undefined>();
+		expectTypeOf(settled.serverError).toEqualTypeOf<undefined>();
 	}
 });
 

--- a/packages/next-safe-action/src/__tests__/validated-middleware.test.ts
+++ b/packages/next-safe-action/src/__tests__/validated-middleware.test.ts
@@ -283,8 +283,9 @@ test("useValidated middleware next() called multiple times returns error", async
 
 	const actualResult = await action({ name: "test" });
 
+	// serverError takes precedence over the first next() call's data per the
+	// result precedence rule (validationErrors > serverError > data).
 	expect(actualResult).toStrictEqual({
-		data: { ok: true },
 		serverError: {
 			message: "next() called multiple times in middleware. Each middleware must call next() at most once.",
 		},

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -299,12 +299,15 @@ export function actionBuilder<
 			throw frameworkErrorHandler.error;
 		}
 
-		// Build the action result.
-		const actionResult: SafeActionResult<ServerError, InputSchema, ShapedErrors, Data> = {};
-
+		// Handle error throws first. `throwValidationErrors` has higher priority
+		// since it's set at the action level and overrides the client setting.
+		// `throwServerError` is gated on the absence of `validationErrors` so that
+		// the advertised precedence (validationErrors > serverError > data) is
+		// honored even when a compound state reaches this point — e.g. invalid
+		// bind args (wrapped as `serverError`) combined with invalid main input
+		// (`validationErrors`). In that case we must not throw the wrapped bind
+		// args server error and lose the actionable field errors.
 		if (typeof middlewareResult.validationErrors !== "undefined") {
-			// `utils.throwValidationErrors` has higher priority since it's set at the action level.
-			// It overrides the client setting, if set.
 			if (
 				winningBoolean(
 					args.throwValidationErrors,
@@ -320,29 +323,41 @@ export function actionBuilder<
 					middlewareResult.validationErrors as ShapedErrors,
 					await overrideErrorMessageFn?.(middlewareResult.validationErrors as ShapedErrors)
 				);
-			} else {
-				actionResult.validationErrors = middlewareResult.validationErrors as ShapedErrors;
 			}
+		} else if (typeof middlewareResult.serverError !== "undefined" && utils?.throwServerError) {
+			throw middlewareResult.serverError;
 		}
 
-		if (typeof middlewareResult.serverError !== "undefined") {
-			if (utils?.throwServerError) {
-				throw middlewareResult.serverError;
-			} else {
-				actionResult.serverError = middlewareResult.serverError;
-			}
+		// The result is a discriminated union: exactly one of `validationErrors`,
+		// `serverError`, or `data` is populated, or the result is idle `{}`.
+		// In compound-error scenarios where the runtime could otherwise produce
+		// multiple populated fields (e.g. `next()` called twice after the action
+		// had already succeeded, or invalid bind args combined with invalid main
+		// input), we apply a fixed precedence: validation errors beat server
+		// errors beat success data. The higher-priority state fully describes
+		// the outcome and lower-priority state is discarded.
+		const hasValidationError = typeof middlewareResult.validationErrors !== "undefined";
+		const hasServerError = typeof middlewareResult.serverError !== "undefined";
+		const treatAsSuccess = middlewareResult.success && !hasValidationError && !hasServerError;
+
+		let actionResult: SafeActionResult<ServerError, InputSchema, ShapedErrors, Data>;
+
+		if (hasValidationError) {
+			actionResult = { validationErrors: middlewareResult.validationErrors as ShapedErrors };
+		} else if (hasServerError) {
+			actionResult = { serverError: middlewareResult.serverError as ServerError };
+		} else if (treatAsSuccess && typeof middlewareResult.data !== "undefined") {
+			actionResult = { data: middlewareResult.data as Data };
+		} else {
+			actionResult = {};
 		}
 
-		if (middlewareResult.success) {
-			if (typeof middlewareResult.data !== "undefined") {
-				actionResult.data = middlewareResult.data as Data;
-			}
-
+		if (treatAsSuccess) {
 			callbackPromises.push(
 				utils?.onSuccess?.({
 					metadata: args.metadata,
 					ctx: currentCtx as Ctx,
-					data: actionResult.data as Data,
+					data: middlewareResult.data as Data,
 					clientInput: mainClientInput,
 					bindArgsClientInputs,
 					parsedInput: middlewareResult.parsedInput as InferOutputOrDefault<InputSchema, undefined>,

--- a/packages/next-safe-action/src/hooks-shared.ts
+++ b/packages/next-safe-action/src/hooks-shared.ts
@@ -9,7 +9,7 @@ import type {
 	SingleInputActionFn,
 	HookShorthandStatus,
 } from "./hooks.types";
-import type { SafeActionResult } from "./index.types";
+import type { NormalizeActionResult, SafeActionResult } from "./index.types";
 import { FrameworkErrorHandler } from "./next/errors";
 import type { InferInputOrDefault, StandardSchemaV1 } from "./standard-schema";
 
@@ -26,11 +26,17 @@ export function useActionBase<ServerError, Schema extends StandardSchemaV1 | und
 	onTransitionStart?: (input: InferInputOrDefault<Schema, undefined>) => void
 ): {
 	isTransitioning: boolean;
-	result: SafeActionResult<ServerError, Schema, ShapedErrors, Data>;
+	// Exposed as `NormalizeActionResult<...>` so that void-returning actions
+	// surface `data: undefined` rather than `data: void | undefined`. The
+	// internal `useState` still holds the raw `SafeActionResult` union — the
+	// type-only narrowing happens once at this boundary via a cast.
+	result: NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>;
 	clientInput: InferInputOrDefault<Schema, void> | undefined;
 	status: HookActionStatus;
 	execute: (input: InferInputOrDefault<Schema, void>) => void;
-	executeAsync: (input: InferInputOrDefault<Schema, void>) => Promise<Awaited<ReturnType<typeof safeActionFn>>>;
+	executeAsync: (
+		input: InferInputOrDefault<Schema, void>
+	) => Promise<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
 	reset: () => void;
 	shorthandStatus: HookShorthandStatus;
 } {
@@ -184,11 +190,20 @@ export function useActionBase<ServerError, Schema extends StandardSchemaV1 | und
 
 	return {
 		isTransitioning,
-		result,
+		// `result` and `executeAsync` are structurally compatible with
+		// `NormalizeActionResult<SafeActionResult<...>>` for every concrete `Data`
+		// the runtime ever produces — `NormalizeActionResult` only drops the
+		// `{ data: void }` branch, which the action builder never emits (see
+		// `buildResultAndRunCallbacks` in `action-builder.ts`). TypeScript can't
+		// verify this while `Data` is still a free generic, so the cast is
+		// isolated here and not repeated across every consumer hook.
+		result: result as unknown as NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>,
 		clientInput,
 		status,
 		execute,
-		executeAsync,
+		executeAsync: executeAsync as unknown as (
+			input: InferInputOrDefault<Schema, void>
+		) => Promise<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>,
 		reset,
 		shorthandStatus: getActionShorthandStatusObject({ status, isTransitioning }),
 	};

--- a/packages/next-safe-action/src/hooks-utils.ts
+++ b/packages/next-safe-action/src/hooks-utils.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import type { HookActionStatus, HookCallbacks, HookShorthandStatus } from "./hooks.types";
-import type { SafeActionResult } from "./index.types";
+import type { NormalizeActionResult, SafeActionResult } from "./index.types";
 import { FrameworkErrorHandler } from "./next/errors";
 import type { InferInputOrDefault, StandardSchemaV1 } from "./standard-schema";
 
@@ -101,7 +101,19 @@ export const useActionCallbacks = <ServerError, Schema extends StandardSchemaV1 
 
 					await Promise.all([
 						Promise.resolve(onSuccess?.({ data: result.data!, input })),
-						Promise.resolve(onSettled?.({ result, input })),
+						// Cast rationale: `onSettled`'s public type uses
+						// `NormalizeActionResult` so void actions surface `data: undefined`,
+						// but internally `result` is the raw `SafeActionResult<..., Data>`.
+						// The two are structurally equivalent for every concrete `Data` the
+						// runtime produces — see the comment in `useActionBase`.
+						Promise.resolve(
+							onSettled?.({
+								result: result as unknown as NormalizeActionResult<
+									SafeActionResult<ServerError, Schema, ShapedErrors, Data>
+								>,
+								input,
+							})
+						),
 					]);
 					break;
 				case "hasErrored":
@@ -112,7 +124,14 @@ export const useActionCallbacks = <ServerError, Schema extends StandardSchemaV1 
 								input,
 							})
 						),
-						Promise.resolve(onSettled?.({ result, input })),
+						Promise.resolve(
+							onSettled?.({
+								result: result as unknown as NormalizeActionResult<
+									SafeActionResult<ServerError, Schema, ShapedErrors, Data>
+								>,
+								input,
+							})
+						),
 					]);
 					break;
 			}
@@ -133,7 +152,15 @@ export const useActionCallbacks = <ServerError, Schema extends StandardSchemaV1 
 							navigationKind: actualNavigationKind,
 						})
 					),
-					Promise.resolve(onSettled?.({ result, input, navigationKind: actualNavigationKind })),
+					Promise.resolve(
+						onSettled?.({
+							result: result as unknown as NormalizeActionResult<
+								SafeActionResult<ServerError, Schema, ShapedErrors, Data>
+							>,
+							input,
+							navigationKind: actualNavigationKind,
+						})
+					),
 				]);
 			}
 		};

--- a/packages/next-safe-action/src/hooks.ts
+++ b/packages/next-safe-action/src/hooks.ts
@@ -6,6 +6,7 @@ import { getActionShorthandStatusObject, getActionStatus, useActionCallbacks } f
 import type {
 	HookBaseOptions,
 	HookCallbacks,
+	HookIdleResult,
 	SingleInputActionFn,
 	SingleInputStateActionFn,
 	UseActionHookReturn,
@@ -113,12 +114,18 @@ export const useOptimisticAction = <
  *
  * {@link https://next-safe-action.dev/docs/execute-actions/hooks/usestateaction See docs for more information}
  */
-export const useStateAction = <ServerError, Schema extends StandardSchemaV1 | undefined, ShapedErrors, Data>(
+export const useStateAction = <
+	ServerError,
+	Schema extends StandardSchemaV1 | undefined,
+	ShapedErrors,
+	Data,
+	InitR extends SafeActionResult<ServerError, Schema, ShapedErrors, Data> = HookIdleResult,
+>(
 	safeActionFn: SingleInputStateActionFn<ServerError, Schema, ShapedErrors, Data>,
 	opts?: {
-		initResult?: Awaited<ReturnType<typeof safeActionFn>>;
+		initResult?: InitR;
 	} & HookBaseOptions<ServerError, Schema, ShapedErrors, Data>
-): UseStateActionHookReturn<ServerError, Schema, ShapedErrors, Data> => {
+): UseStateActionHookReturn<ServerError, Schema, ShapedErrors, Data, InitR> => {
 	if (typeof React.useActionState !== "function") {
 		throw new Error(
 			"useStateAction requires React 19+ (Next.js 15+). " +
@@ -234,7 +241,12 @@ export const useStateAction = <ServerError, Schema extends StandardSchemaV1 | un
 
 	// ─── Status ───────────────────────────────────────────────────────────
 
-	const result = isReset ? ({} as SafeActionResult<ServerError, Schema, ShapedErrors, Data>) : (rawResult ?? {});
+	// On reset, the visible `result` is restored to `initResult` (or `{}` when not provided) so
+	// the idle branch's runtime value matches its declared type in both phases: at mount and
+	// after reset. This is also the intuitive contract for `reset` — return to the initial state.
+	const result = isReset
+		? ((initResult ?? {}) as SafeActionResult<ServerError, Schema, ShapedErrors, Data>)
+		: (rawResult ?? {});
 
 	const status = getActionStatus<ServerError, Schema, ShapedErrors, Data>({
 		isExecuting,
@@ -277,7 +289,7 @@ export const useStateAction = <ServerError, Schema extends StandardSchemaV1 | un
 		reset,
 		status,
 		...getActionShorthandStatusObject({ status, isTransitioning }),
-	} as unknown as UseStateActionHookReturn<ServerError, Schema, ShapedErrors, Data>;
+	} as unknown as UseStateActionHookReturn<ServerError, Schema, ShapedErrors, Data, InitR>;
 };
 
 export type * from "./hooks.types";

--- a/packages/next-safe-action/src/hooks.ts
+++ b/packages/next-safe-action/src/hooks.ts
@@ -12,7 +12,7 @@ import type {
 	UseOptimisticActionHookReturn,
 	UseStateActionHookReturn,
 } from "./hooks.types";
-import type { SafeActionResult } from "./index.types";
+import type { NormalizeActionResult, SafeActionResult } from "./index.types";
 import { FrameworkErrorHandler } from "./next/errors";
 import type { InferInputOrDefault, StandardSchemaV1 } from "./standard-schema";
 
@@ -254,12 +254,16 @@ export const useStateAction = <ServerError, Schema extends StandardSchemaV1 | un
 
 	// ─── Return ───────────────────────────────────────────────────────────
 
+	// See `useActionBase` in hooks-shared.ts for the rationale behind the
+	// `NormalizeActionResult` cast — same invariant applies here.
 	return {
 		execute,
-		executeAsync,
+		executeAsync: executeAsync as unknown as (
+			input: InferInputOrDefault<Schema, void>
+		) => Promise<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>,
 		formAction: dispatcher as (input: InferInputOrDefault<Schema, void>) => void,
 		input: clientInput as InferInputOrDefault<Schema, undefined>,
-		result,
+		result: result as unknown as NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>,
 		reset,
 		status,
 		...getActionShorthandStatusObject({ status, isTransitioning }),

--- a/packages/next-safe-action/src/hooks.ts
+++ b/packages/next-safe-action/src/hooks.ts
@@ -34,6 +34,10 @@ export const useAction = <ServerError, Schema extends StandardSchemaV1 | undefin
 		opts
 	);
 
+	// Cast rationale: the return object's runtime values are guaranteed consistent
+	// by `getActionStatus` + `getActionShorthandStatusObject`, but TypeScript can't
+	// verify that the widened types (e.g. `status: HookActionStatus`) satisfy a
+	// specific branch of the discriminated union. The cast is safe and isolated here.
 	return {
 		execute,
 		executeAsync,
@@ -42,7 +46,7 @@ export const useAction = <ServerError, Schema extends StandardSchemaV1 | undefin
 		reset,
 		status,
 		...shorthandStatus,
-	};
+	} as UseActionHookReturn<ServerError, Schema, ShapedErrors, Data>;
 };
 
 /**
@@ -79,6 +83,10 @@ export const useOptimisticAction = <
 		setOptimisticValue
 	);
 
+	// Cast rationale: same as `useAction` — runtime consistency guaranteed by
+	// `getActionStatus` + `getActionShorthandStatusObject`. The double assertion
+	// is needed because TypeScript can't verify overlap between the widened object
+	// and the distributed intersection-over-union (`UseActionHookReturn & { optimisticState }`).
 	return {
 		execute,
 		executeAsync,
@@ -88,7 +96,7 @@ export const useOptimisticAction = <
 		reset,
 		status,
 		...shorthandStatus,
-	};
+	} as unknown as UseOptimisticActionHookReturn<ServerError, Schema, ShapedErrors, Data, State>;
 };
 
 /**
@@ -254,8 +262,10 @@ export const useStateAction = <ServerError, Schema extends StandardSchemaV1 | un
 
 	// ─── Return ───────────────────────────────────────────────────────────
 
-	// See `useActionBase` in hooks-shared.ts for the rationale behind the
-	// `NormalizeActionResult` cast — same invariant applies here.
+	// Cast rationale: same as `useAction` — runtime consistency guaranteed by
+	// `getActionStatus` + `getActionShorthandStatusObject`. The double assertion
+	// through `unknown` is needed because TypeScript can't verify overlap between
+	// the widened object and the distributed intersection-over-union.
 	return {
 		execute,
 		executeAsync: executeAsync as unknown as (
@@ -267,7 +277,7 @@ export const useStateAction = <ServerError, Schema extends StandardSchemaV1 | un
 		reset,
 		status,
 		...getActionShorthandStatusObject({ status, isTransitioning }),
-	};
+	} as unknown as UseStateActionHookReturn<ServerError, Schema, ShapedErrors, Data>;
 };
 
 export type * from "./hooks.types";

--- a/packages/next-safe-action/src/hooks.types.ts
+++ b/packages/next-safe-action/src/hooks.types.ts
@@ -66,7 +66,7 @@ export type SingleInputStateActionFn<ServerError, Schema extends StandardSchemaV
 /**
  * Type of the action status returned by `useAction`, `useOptimisticAction` and `useStateAction` hooks.
  */
-export type HookActionStatus = "idle" | "executing" | "transitioning" | "hasSucceeded" | "hasErrored" | "hasNavigated";
+export type HookActionStatus = "idle" | "executing" | "hasSucceeded" | "hasErrored" | "hasNavigated";
 
 /**
  * Type of the shorthand status object returned by `useAction`, `useOptimisticAction` and `useStateAction` hooks.
@@ -82,25 +82,126 @@ export type HookShorthandStatus = {
 };
 
 /**
- * Type of the return object of the `useAction` hook.
- *
- * `result` and `executeAsync` are run through `NormalizeActionResult` so that
- * void-returning actions expose `result.data: undefined` rather than `void | undefined`,
- * matching the `await action()` shape from `SafeActionFn`.
+ * Result shape when no action has completed yet (idle, executing, navigated).
  */
-export type UseActionHookReturn<ServerError, Schema extends StandardSchemaV1 | undefined, ShapedErrors, Data> = {
+export type HookIdleResult = { data?: undefined; serverError?: undefined; validationErrors?: undefined };
+
+/**
+ * Result shape for the success branch. For void-returning actions, collapses to `HookIdleResult`
+ * so that `result.data` is `undefined` rather than `void`.
+ */
+export type HookSuccessResult<Data> = [Data] extends [void]
+	? HookIdleResult
+	: { data: Data; serverError?: undefined; validationErrors?: undefined };
+
+/**
+ * Result shape for the error branch. Includes the idle shape for thrown errors
+ * (where `result` is `{}` and the error is captured internally).
+ */
+export type HookErrorResult<ServerError, ShapedErrors> =
+	| HookIdleResult
+	| { data?: undefined; serverError: ServerError; validationErrors?: undefined }
+	| { data?: undefined; serverError?: undefined; validationErrors: ShapedErrors };
+
+/**
+ * Common properties shared across all status branches of the hook return type.
+ */
+type HookResultCommon<ServerError, Schema extends StandardSchemaV1 | undefined, ShapedErrors, Data> = {
 	execute: (input: InferInputOrDefault<Schema, void>) => void;
 	executeAsync: (
 		input: InferInputOrDefault<Schema, void>
 	) => Promise<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
 	input: InferInputOrDefault<Schema, undefined>;
-	result: Prettify<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
 	reset: () => void;
-	status: HookActionStatus;
-} & HookShorthandStatus;
+	isTransitioning: boolean;
+};
+
+/**
+ * Type of the return object of the `useAction` hook.
+ *
+ * This is a discriminated union keyed on `status` and the shorthand boolean
+ * properties (`hasSucceeded`, `hasErrored`, etc.). Checking any discriminant
+ * narrows the `result` type:
+ *
+ * ```ts
+ * const action = useAction(myAction);
+ * if (action.hasSucceeded) {
+ *   action.result.data        // Data (guaranteed)
+ *   action.result.serverError // undefined
+ * }
+ * ```
+ *
+ * Destructured narrowing works too (TypeScript 4.6+):
+ *
+ * ```ts
+ * const { status, result } = useAction(myAction);
+ * if (status === "hasSucceeded") {
+ *   result.data // narrowed to Data
+ * }
+ * ```
+ *
+ * `result` and `executeAsync` are run through `NormalizeActionResult` so that
+ * void-returning actions expose `result.data: undefined` rather than `void | undefined`.
+ */
+export type UseActionHookReturn<ServerError, Schema extends StandardSchemaV1 | undefined, ShapedErrors, Data> =
+	HookResultCommon<ServerError, Schema, ShapedErrors, Data> &
+		(
+			| {
+					status: "idle";
+					isIdle: true;
+					isExecuting: false;
+					isPending: boolean;
+					hasSucceeded: false;
+					hasErrored: false;
+					hasNavigated: false;
+					result: Prettify<HookIdleResult>;
+			  }
+			| {
+					status: "executing";
+					isIdle: false;
+					isExecuting: true;
+					isPending: true;
+					hasSucceeded: false;
+					hasErrored: false;
+					hasNavigated: false;
+					result: Prettify<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
+			  }
+			| {
+					status: "hasSucceeded";
+					isIdle: false;
+					isExecuting: false;
+					isPending: boolean;
+					hasSucceeded: true;
+					hasErrored: false;
+					hasNavigated: false;
+					result: Prettify<HookSuccessResult<Data>>;
+			  }
+			| {
+					status: "hasErrored";
+					isIdle: false;
+					isExecuting: false;
+					isPending: boolean;
+					hasSucceeded: false;
+					hasErrored: true;
+					hasNavigated: false;
+					result: Prettify<HookErrorResult<ServerError, ShapedErrors>>;
+			  }
+			| {
+					status: "hasNavigated";
+					isIdle: false;
+					isExecuting: false;
+					isPending: boolean;
+					hasSucceeded: false;
+					hasErrored: false;
+					hasNavigated: true;
+					result: Prettify<HookIdleResult>;
+			  }
+		);
 
 /**
  * Type of the return object of the `useOptimisticAction` hook.
+ * Extends `UseActionHookReturn` with `optimisticState`. TypeScript distributes
+ * the intersection over the union, preserving the discriminated union narrowing.
  */
 export type UseOptimisticActionHookReturn<
 	ServerError,
@@ -108,24 +209,23 @@ export type UseOptimisticActionHookReturn<
 	ShapedErrors,
 	Data,
 	State,
-> = UseActionHookReturn<ServerError, Schema, ShapedErrors, Data> &
-	HookShorthandStatus & {
-		optimisticState: State;
-	};
+> = UseActionHookReturn<ServerError, Schema, ShapedErrors, Data> & {
+	optimisticState: State;
+};
 
 /**
  * Type of the return object of the `useStateAction` hook.
  * Extends `UseActionHookReturn` with `formAction` for `<form action={formAction}>` integration.
+ * TypeScript distributes the intersection over the union, preserving the discriminated union narrowing.
  */
 export type UseStateActionHookReturn<
 	ServerError,
 	Schema extends StandardSchemaV1 | undefined,
 	ShapedErrors,
 	Data,
-> = UseActionHookReturn<ServerError, Schema, ShapedErrors, Data> &
-	HookShorthandStatus & {
-		formAction: (input: InferInputOrDefault<Schema, void>) => void;
-	};
+> = UseActionHookReturn<ServerError, Schema, ShapedErrors, Data> & {
+	formAction: (input: InferInputOrDefault<Schema, void>) => void;
+};
 
 /**
  * Type of the return object of the `useAction` hook.

--- a/packages/next-safe-action/src/hooks.types.ts
+++ b/packages/next-safe-action/src/hooks.types.ts
@@ -143,60 +143,64 @@ type HookResultCommon<ServerError, Schema extends StandardSchemaV1 | undefined, 
  * `result` and `executeAsync` are run through `NormalizeActionResult` so that
  * void-returning actions expose `result.data: undefined` rather than `void | undefined`.
  */
-export type UseActionHookReturn<ServerError, Schema extends StandardSchemaV1 | undefined, ShapedErrors, Data> =
-	HookResultCommon<ServerError, Schema, ShapedErrors, Data> &
-		(
-			| {
-					status: "idle";
-					isIdle: true;
-					isExecuting: false;
-					isPending: boolean;
-					hasSucceeded: false;
-					hasErrored: false;
-					hasNavigated: false;
-					result: Prettify<HookIdleResult>;
-			  }
-			| {
-					status: "executing";
-					isIdle: false;
-					isExecuting: true;
-					isPending: true;
-					hasSucceeded: false;
-					hasErrored: false;
-					hasNavigated: false;
-					result: Prettify<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
-			  }
-			| {
-					status: "hasSucceeded";
-					isIdle: false;
-					isExecuting: false;
-					isPending: boolean;
-					hasSucceeded: true;
-					hasErrored: false;
-					hasNavigated: false;
-					result: Prettify<HookSuccessResult<Data>>;
-			  }
-			| {
-					status: "hasErrored";
-					isIdle: false;
-					isExecuting: false;
-					isPending: boolean;
-					hasSucceeded: false;
-					hasErrored: true;
-					hasNavigated: false;
-					result: Prettify<HookErrorResult<ServerError, ShapedErrors>>;
-			  }
-			| {
-					status: "hasNavigated";
-					isIdle: false;
-					isExecuting: false;
-					isPending: boolean;
-					hasSucceeded: false;
-					hasErrored: false;
-					hasNavigated: true;
-					result: Prettify<HookIdleResult>;
-			  }
-		);
+export type UseActionHookReturn<
+	ServerError,
+	Schema extends StandardSchemaV1 | undefined,
+	ShapedErrors,
+	Data,
+> = HookResultCommon<ServerError, Schema, ShapedErrors, Data> &
+	(
+		| {
+				status: "idle";
+				isIdle: true;
+				isExecuting: false;
+				isPending: boolean;
+				hasSucceeded: false;
+				hasErrored: false;
+				hasNavigated: false;
+				result: Prettify<HookIdleResult>;
+		  }
+		| {
+				status: "executing";
+				isIdle: false;
+				isExecuting: true;
+				isPending: true;
+				hasSucceeded: false;
+				hasErrored: false;
+				hasNavigated: false;
+				result: Prettify<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
+		  }
+		| {
+				status: "hasSucceeded";
+				isIdle: false;
+				isExecuting: false;
+				isPending: boolean;
+				hasSucceeded: true;
+				hasErrored: false;
+				hasNavigated: false;
+				result: Prettify<HookSuccessResult<Data>>;
+		  }
+		| {
+				status: "hasErrored";
+				isIdle: false;
+				isExecuting: false;
+				isPending: boolean;
+				hasSucceeded: false;
+				hasErrored: true;
+				hasNavigated: false;
+				result: Prettify<HookErrorResult<ServerError, ShapedErrors>>;
+		  }
+		| {
+				status: "hasNavigated";
+				isIdle: false;
+				isExecuting: false;
+				isPending: boolean;
+				hasSucceeded: false;
+				hasErrored: false;
+				hasNavigated: true;
+				result: Prettify<HookIdleResult>;
+		  }
+	);
 
 /**
  * Type of the return object of the `useOptimisticAction` hook.
@@ -215,15 +219,34 @@ export type UseOptimisticActionHookReturn<
 
 /**
  * Type of the return object of the `useStateAction` hook.
+ *
  * Extends `UseActionHookReturn` with `formAction` for `<form action={formAction}>` integration.
  * TypeScript distributes the intersection over the union, preserving the discriminated union narrowing.
+ *
+ * The optional `InitR` generic represents the shape of the `initResult` option. When provided,
+ * it narrows the idle branch's `result` to exactly that shape, so seeded fields are typed as
+ * required rather than `Data | undefined`. For example, `initResult: { data: { id: 1 } }` gives
+ * `result.data` the type `{ id: number }` on the idle branch — matching the runtime value that
+ * is seeded at mount and restored after `reset()`. Defaults to `HookIdleResult` (empty result)
+ * when `initResult` is not provided.
  */
 export type UseStateActionHookReturn<
 	ServerError,
 	Schema extends StandardSchemaV1 | undefined,
 	ShapedErrors,
 	Data,
-> = UseActionHookReturn<ServerError, Schema, ShapedErrors, Data> & {
+	InitR extends SafeActionResult<ServerError, Schema, ShapedErrors, Data> = HookIdleResult,
+> = (UseActionHookReturn<ServerError, Schema, ShapedErrors, Data> extends infer R
+	? R extends { status: "idle" }
+		? Omit<R, "result"> & {
+				result: Prettify<{
+					data: "data" extends keyof InitR ? InitR["data"] : undefined;
+					serverError: "serverError" extends keyof InitR ? InitR["serverError"] : undefined;
+					validationErrors: "validationErrors" extends keyof InitR ? InitR["validationErrors"] : undefined;
+				}>;
+			}
+		: R
+	: never) & {
 	formAction: (input: InferInputOrDefault<Schema, void>) => void;
 };
 

--- a/packages/next-safe-action/src/hooks.types.ts
+++ b/packages/next-safe-action/src/hooks.types.ts
@@ -1,4 +1,10 @@
-import type { NavigationKind, SafeActionFn, SafeActionResult, SafeStateActionFn } from "./index.types";
+import type {
+	NavigationKind,
+	NormalizeActionResult,
+	SafeActionFn,
+	SafeActionResult,
+	SafeStateActionFn,
+} from "./index.types";
 import type { InferInputOrDefault, StandardSchemaV1 } from "./standard-schema";
 import type { MaybePromise, Prettify } from "./utils.types";
 
@@ -34,7 +40,7 @@ export type HookCallbacks<ServerError, Schema extends StandardSchemaV1 | undefin
 		navigationKind: NavigationKind;
 	}) => MaybePromise<unknown>;
 	onSettled?: (args: {
-		result: Prettify<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>;
+		result: Prettify<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
 		input: InferInputOrDefault<Schema, undefined>;
 		navigationKind?: NavigationKind;
 	}) => MaybePromise<unknown>;
@@ -77,14 +83,18 @@ export type HookShorthandStatus = {
 
 /**
  * Type of the return object of the `useAction` hook.
+ *
+ * `result` and `executeAsync` are run through `NormalizeActionResult` so that
+ * void-returning actions expose `result.data: undefined` rather than `void | undefined`,
+ * matching the `await action()` shape from `SafeActionFn`.
  */
 export type UseActionHookReturn<ServerError, Schema extends StandardSchemaV1 | undefined, ShapedErrors, Data> = {
 	execute: (input: InferInputOrDefault<Schema, void>) => void;
 	executeAsync: (
 		input: InferInputOrDefault<Schema, void>
-	) => Promise<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>;
+	) => Promise<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
 	input: InferInputOrDefault<Schema, undefined>;
-	result: Prettify<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>;
+	result: Prettify<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
 	reset: () => void;
 	status: HookActionStatus;
 } & HookShorthandStatus;

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -168,6 +168,16 @@ export type CreateClientOpts<
  * - success (only `data` is set)
  * - server error (only `serverError` is set)
  * - validation error (only `validationErrors` is set)
+ *
+ * Note: when `Data` is `void` (the action returns nothing), the success
+ * branch's `data` becomes `void`, which is indistinguishable from the idle
+ * branch's `data?: undefined` at read time. For public, user-facing types
+ * (`SafeActionFn`, `SafeStateActionFn`, hook return types), `NormalizeActionResult`
+ * is applied at the boundary to drop the void-success branch entirely,
+ * giving `r.data` an exact `undefined` type. This type is kept unconditional
+ * so that internal builders in `action-builder.ts` and `hooks-shared.ts`
+ * can construct `{ data: Data }` assignments without fighting deferred
+ * conditional types.
  */
 export type SafeActionResult<
 	ServerError,
@@ -183,7 +193,32 @@ export type SafeActionResult<
 	| { data?: undefined; serverError?: undefined; validationErrors: ShapedErrors };
 
 /**
+ * Collapses the void-success branch of a `SafeActionResult` union.
+ *
+ * The runtime never emits `{ data: undefined }` for a void-returning action
+ * (see `buildResultAndRunCallbacks` in `action-builder.ts` — it only sets
+ * `data` when `middlewareResult.data !== undefined`). For user-facing types,
+ * we drop the `{ data: void }` branch so that `r.data` narrows to exactly
+ * `undefined` instead of `void | undefined`.
+ *
+ * This is a distributive conditional — each member of the input union is
+ * checked individually. Only the exact `{ data: void }` shape is excluded;
+ * other branches (idle, server error, validation error) pass through.
+ *
+ * When `Data` is not exactly `void`, the success branch doesn't match the
+ * filter and the whole union is returned unchanged.
+ */
+export type NormalizeActionResult<R> = R extends { data: infer D }
+	? [D] extends [void]
+		? Exclude<R, { data: D }>
+		: R
+	: R;
+
+/**
  * Type of the function called from components with type safe input data.
+ *
+ * The awaited result is run through `NormalizeActionResult` so that
+ * void-returning actions expose `data: undefined` rather than `data: void | undefined`.
  */
 export type SafeActionFn<
 	ServerError,
@@ -193,10 +228,13 @@ export type SafeActionFn<
 	Data,
 > = (
 	...clientInputs: [...bindArgsInputs: InferInputArray<BindArgsSchemas>, input: InferInputOrDefault<Schema, void>]
-) => Promise<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>;
+) => Promise<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
 
 /**
  * Type of the stateful function called from components with type safe input data.
+ *
+ * Both `prevResult` and the awaited result are run through `NormalizeActionResult`
+ * so that `useStateAction` consumers see `data: undefined` for void-returning actions.
  */
 export type SafeStateActionFn<
 	ServerError,
@@ -207,10 +245,10 @@ export type SafeStateActionFn<
 > = (
 	...clientInputs: [
 		...bindArgsInputs: InferInputArray<BindArgsSchemas>,
-		prevResult: Prettify<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>,
+		prevResult: Prettify<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>,
 		input: InferInputOrDefault<Schema, void>,
 	]
-) => Promise<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>;
+) => Promise<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
 
 /**
  * Type of the result of a middleware function. Carries the same data/error fields as
@@ -415,24 +453,12 @@ export type InferSafeActionFnInput<T extends Function> = T extends
 
 /**
  * Infer the result type of a safe action.
+ *
+ * Extracted via `Awaited<ReturnType<T>>` so that the `NormalizeActionResult`
+ * wrapper applied in `SafeActionFn`/`SafeStateActionFn` flows through (i.e.
+ * void-returning actions yield `data: undefined` rather than `data: void`).
  */
-export type InferSafeActionFnResult<T extends Function> = T extends
-	| SafeActionFn<
-			infer ServerError,
-			infer Schema extends StandardSchemaV1 | undefined,
-			any,
-			infer ShapedErrors,
-			infer Data
-	  >
-	| SafeStateActionFn<
-			infer ServerError,
-			infer Schema extends StandardSchemaV1 | undefined,
-			any,
-			infer ShapedErrors,
-			infer Data
-	  >
-	? SafeActionResult<ServerError, Schema, ShapedErrors, Data>
-	: never;
+export type InferSafeActionFnResult<T extends Function> = T extends (...args: any[]) => Promise<infer R> ? R : never;
 
 /**
  * Infer the next context type returned by a middleware function using the `next` function.

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -149,6 +149,25 @@ export type CreateClientOpts<
 
 /**
  * Type of the result of a safe action.
+ *
+ * Modeled as a discriminated union so that checking one field narrows the
+ * others to `undefined`. The runtime guarantees mutual exclusion (see
+ * `buildResultAndRunCallbacks` in `action-builder.ts`), and this type makes
+ * that guarantee visible to consumers:
+ *
+ * ```ts
+ * const { data, serverError, validationErrors } = await myAction(input);
+ *
+ * if (data) {
+ *   // TS knows serverError and validationErrors are undefined here
+ * }
+ * ```
+ *
+ * Branches:
+ * - idle / initial state (e.g. `useAction`'s `useState<Result>({})`)
+ * - success (only `data` is set)
+ * - server error (only `serverError` is set)
+ * - validation error (only `validationErrors` is set)
  */
 export type SafeActionResult<
 	ServerError,
@@ -157,11 +176,11 @@ export type SafeActionResult<
 	Data = unknown,
 	// oxlint-disable-next-line
 	NextCtx = object,
-> = {
-	data?: Data;
-	serverError?: ServerError;
-	validationErrors?: ShapedErrors;
-};
+> =
+	| { data?: undefined; serverError?: undefined; validationErrors?: undefined }
+	| { data: Data; serverError?: undefined; validationErrors?: undefined }
+	| { data?: undefined; serverError: ServerError; validationErrors?: undefined }
+	| { data?: undefined; serverError?: undefined; validationErrors: ShapedErrors };
 
 /**
  * Type of the function called from components with type safe input data.
@@ -194,16 +213,30 @@ export type SafeStateActionFn<
 ) => Promise<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>;
 
 /**
- * Type of the result of a middleware function. It extends the result of a safe action with
- * information about the action execution.
+ * Type of the result of a middleware function. Carries the same data/error fields as
+ * `SafeActionResult` plus internal bookkeeping (navigation kind, parsed inputs, context,
+ * success flag).
+ *
+ * This is intentionally a flat object rather than `SafeActionResult & { ... }`, because
+ * `SafeActionResult` is now a discriminated union and intersecting it with additional
+ * fields would prevent mutation of `data`/`serverError`/`validationErrors` during
+ * middleware execution. The public shape (the set of readable fields) is unchanged.
+ *
+ * `NextCtx` is a phantom generic parameter kept for backward compatibility with the
+ * previous signature — it is intentionally unused in the body so that
+ * `MiddlewareResult<SE, A>` and `MiddlewareResult<SE, B>` remain mutually assignable
+ * (as they were when this type intersected `SafeActionResult<..., NextCtx>`, where
+ * `NextCtx` was likewise phantom).
  */
-export type MiddlewareResult<ServerError, NextCtx extends object> = SafeActionResult<
-	ServerError,
-	any,
-	any,
-	any,
-	NextCtx
-> & {
+// `data` and `validationErrors` are intentionally typed as `any` to match the
+// previous definition (`SafeActionResult<ServerError, any, any, any, NextCtx>
+// & { ... }`), preserving universal-donor assignability for middleware authors
+// who inspect the return value of `await next()`.
+// oxlint-disable-next-line no-unused-vars
+export type MiddlewareResult<ServerError, NextCtx extends object> = {
+	data?: any;
+	serverError?: ServerError;
+	validationErrors?: any;
 	navigationKind?: NavigationKind;
 	parsedInput?: unknown;
 	bindArgsParsedInputs?: unknown[];

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -171,13 +171,14 @@ export type CreateClientOpts<
  *
  * Note: when `Data` is `void` (the action returns nothing), the success
  * branch's `data` becomes `void`, which is indistinguishable from the idle
- * branch's `data?: undefined` at read time. For public, user-facing types
- * (`SafeActionFn`, `SafeStateActionFn`, hook return types), `NormalizeActionResult`
- * is applied at the boundary to drop the void-success branch entirely,
- * giving `r.data` an exact `undefined` type. This type is kept unconditional
- * so that internal builders in `action-builder.ts` and `hooks-shared.ts`
- * can construct `{ data: Data }` assignments without fighting deferred
- * conditional types.
+ * branch's `data?: undefined` at read time. Hook return types apply
+ * `NormalizeActionResult` at the boundary to drop the void-success branch
+ * entirely, giving `result.data` an exact `undefined` type.
+ *
+ * `NormalizeActionResult` is NOT applied on `SafeActionFn`/`SafeStateActionFn`
+ * return types because doing so causes TypeScript to eagerly expand the
+ * discriminated union when `.bind()` is used, breaking generic inference for
+ * hooks (the `Schema` parameter falls back to `StandardSchemaV1<unknown, unknown>`).
  */
 export type SafeActionResult<
 	ServerError,
@@ -216,9 +217,6 @@ export type NormalizeActionResult<R> = R extends { data: infer D }
 
 /**
  * Type of the function called from components with type safe input data.
- *
- * The awaited result is run through `NormalizeActionResult` so that
- * void-returning actions expose `data: undefined` rather than `data: void | undefined`.
  */
 export type SafeActionFn<
 	ServerError,
@@ -228,13 +226,10 @@ export type SafeActionFn<
 	Data,
 > = (
 	...clientInputs: [...bindArgsInputs: InferInputArray<BindArgsSchemas>, input: InferInputOrDefault<Schema, void>]
-) => Promise<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
+) => Promise<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>;
 
 /**
  * Type of the stateful function called from components with type safe input data.
- *
- * Both `prevResult` and the awaited result are run through `NormalizeActionResult`
- * so that `useStateAction` consumers see `data: undefined` for void-returning actions.
  */
 export type SafeStateActionFn<
 	ServerError,
@@ -245,10 +240,10 @@ export type SafeStateActionFn<
 > = (
 	...clientInputs: [
 		...bindArgsInputs: InferInputArray<BindArgsSchemas>,
-		prevResult: Prettify<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>,
+		prevResult: Prettify<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>,
 		input: InferInputOrDefault<Schema, void>,
 	]
-) => Promise<NormalizeActionResult<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>>;
+) => Promise<SafeActionResult<ServerError, Schema, ShapedErrors, Data>>;
 
 /**
  * Type of the result of a middleware function. Carries the same data/error fields as
@@ -453,10 +448,6 @@ export type InferSafeActionFnInput<T extends Function> = T extends
 
 /**
  * Infer the result type of a safe action.
- *
- * Extracted via `Awaited<ReturnType<T>>` so that the `NormalizeActionResult`
- * wrapper applied in `SafeActionFn`/`SafeStateActionFn` flows through (i.e.
- * void-returning actions yield `data: undefined` rather than `data: void`).
  */
 export type InferSafeActionFnResult<T extends Function> = T extends (...args: any[]) => Promise<infer R> ? R : never;
 

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,9 @@
 			"outputs": [".next/**", "!.next/cache/**", "dist/**", "build/**"],
 			"env": ["SPONSORS_GITHUB_TOKEN"]
 		},
-		"test": {},
+		"test": {
+			"dependsOn": ["^build"]
+		},
 		"lint": {
 			"dependsOn": ["^build"]
 		},


### PR DESCRIPTION
## Summary

This PR makes the result types returned by both server actions and client hooks accurately reflect the runtime guarantee that `data`, `serverError`, and `validationErrors` are mutually exclusive. The result type is now a proper discriminated union, so checking one field narrows the others to `undefined` automatically. Hook return types are likewise narrowed against `status`, so `result.data` is typed as `Data` (not `Data | undefined`) once `hasSucceeded` is true, and similar narrowing applies to error and idle branches.

To make the new types honest, the action builder now applies a fixed precedence rule when building the result, so it can no longer produce compound states with multiple populated fields. Documentation, type tests, and runtime tests were updated and expanded to cover the new behavior end-to-end.

## What changed

### Type-level

- **`SafeActionResult` is now a discriminated union.** The four branches are: idle (`{}`), success (`{ data }`), server error (`{ serverError }`), and validation error (`{ validationErrors }`). Checking any single field narrows the other two to `undefined`.
- **Hook return types are discriminated unions on `status`.** `useAction`, `useOptimisticAction`, and `useStateAction` now return a union keyed on `status` and the shorthand booleans (`hasSucceeded`, `hasErrored`, etc.), so narrowing on any one of them narrows `result` to the appropriate branch.
- **Void-success branch collapsed at hook boundaries.** A new `NormalizeActionResult` type drops the `{ data: void }` branch from user-facing hook return types, so `result.data` reads as exactly `undefined` rather than `void | undefined` for void-returning actions.
- **`HookActionStatus` no longer includes `"transitioning"`.** That value was never actually assigned at runtime. The `isTransitioning` boolean on the hook return object is unchanged.
- **`useStateAction` gains an `InitR` generic.** When `initResult` is provided, the idle branch's `result` is narrowed to that exact shape, so seeded fields are typed as required rather than `Data | undefined`. `initResult` is also restored on `reset()` to match this typing.
- **`MiddlewareResult` is now a flat object** (rather than `SafeActionResult & { ... }`) so the discriminated union does not interfere with internal field mutation during middleware execution. The set of readable fields for middleware authors is unchanged.
- **`InferSafeActionFnResult` simplified** to derive the result type directly from the function's `Promise` return.

### Runtime

The action builder now applies a fixed precedence rule when assembling the final result: `validationErrors` > `serverError` > `data`. In rare compound-error scenarios that previously produced multiple populated fields, only the highest-priority field survives:

- **Middleware calling `next()` twice.** Previously the result contained both the first call's `data` and a `serverError` describing the second call. Now only the `serverError` is returned. The runtime guard against multiple `next()` calls is unchanged.
- **Invalid bind args combined with invalid main input.** Previously the result contained both a wrapped `serverError` (bind args) and `validationErrors` (main input). Now only the `validationErrors` is returned. The bind args error surfaces on the next attempt once main input is fixed.

### Documentation

- Updated `concepts/action-result.mdx` and `api/types.mdx` to describe the discriminated union and its narrowing behavior.
- New section in `concepts/error-handling.mdx` documenting the error precedence rule and how it interacts with `handleServerError`.
- Updated `guides/hooks.mdx` and `api/hooks-api.mdx` for the new hook return type narrowing.
- Removed lingering `useStateAction` deprecation notices.

### Tests

- New type-level tests in `__tests__/types/result-narrowing.test-d.ts`, `__tests__/types/action-result.test-d.ts`, and significant additions to `__tests__/types/hooks-return.test-d.ts` and `__tests__/types/middleware-ctx.test-d.ts`.
- New runtime tests covering compound-error scenarios in `__tests__/middleware-edge-cases.test.ts`, plus expanded coverage in `__tests__/bind-args-validation-errors.test.ts`, `__tests__/navigation-errors.test.ts`, and `__tests__/stateful-hooks.test.tsx`.

## Migration guide

The typical `useAction()` / `await myAction(input)` consumer requires no changes. Below are the situations to check for after upgrading. All of them are rare in practice, and the fixes are mechanical.

### 1. Tests or mocks that assert on compound result objects

If you have tests that assert on a result containing more than one populated field (e.g. `{ data, serverError }` or `{ serverError, validationErrors }` simultaneously), they will fail, both because the discriminated union rejects them at the type level and because the runtime no longer produces them.

```ts
// Before
expect(result).toStrictEqual({
  serverError: "Invalid bind arg",
  validationErrors: { fieldErrors: { name: ["Required"] } },
});

// After: validation errors win, bind args error surfaces on the next attempt
expect(result).toStrictEqual({
  validationErrors: { fieldErrors: { name: ["Required"] } },
});
```

If you manually constructed `SafeActionResult` values in fixtures, split them into one object per branch (idle, success, server error, validation error).

### 2. Exhaustive `switch` on `status` with a `"transitioning"` case

The `"transitioning"` value has been removed from the `HookActionStatus` union. It was never actually assigned at runtime, but if you had a `case "transitioning":` in an exhaustive `switch`, TypeScript will now complain that the case is unreachable.

```ts
// Before
switch (action.status) {
  case "idle": /* … */ break;
  case "executing": /* … */ break;
  case "transitioning": /* … */ break; // unreachable, delete this case
  case "hasSucceeded": /* … */ break;
  case "hasErrored": /* … */ break;
  case "hasNavigated": /* … */ break;
}
```

The `isTransitioning` boolean on the hook return object is unchanged. If you were relying on it for React transition state, nothing needs to change.

### 3. Code that reshapes the hook return type

The return types of `useAction`, `useOptimisticAction`, and `useStateAction` are now discriminated unions keyed on `status`. Reading fields directly (`action.result.data`, `action.hasSucceeded`, etc.) works exactly as before. You only need to take action if you:

- Use `Pick`/`Omit`/`Partial` on `UseActionHookReturn` and expected a flat shape. These utilities now distribute over the union.
- Build custom wrappers that manually construct a value of type `UseActionHookReturn` (e.g. a test helper). The value must match exactly one branch of the union rather than the previous flat shape.

The `result` object on each branch is now narrowed. For example, on the `"hasSucceeded"` branch, `result.data` is typed as `Data` (not `Data | undefined`). This is strictly more information than before, and existing code that reads it without narrowing continues to compile.

## Versioning

Released as a **minor** version bump. No adapter packages (`adapter-react-hook-form`, `adapter-tanstack-query`, `adapter-better-auth`) require code changes; they remain compatible with the updated types.