### PR TITLE
inline deepmerge logic

### DIFF
--- a/.changeset/inline-deepmerge.md
+++ b/.changeset/inline-deepmerge.md
@@ -1,0 +1,5 @@
+---
+"next-safe-action": patch
+---
+
+Remove the `deepmerge-ts` runtime dependency by inlining the small subset of deep-merge logic the library actually uses into an internal `deep-merge.ts`. Behavior is unchanged (records merged recursively, arrays concatenated, Sets/Maps combined, otherwise last value wins, with a `__proto__` pollution guard), and the package now ships with zero runtime dependencies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ The library has three entry points: `next-safe-action` (server), `next-safe-acti
 **Server-side core:**
 - `safe-action-client.ts`: `SafeActionClient` class with chainable methods: `use()` (middleware), `metadata()`, `inputSchema()`, `outputSchema()`, `bindArgsSchema()`, `action()`, `stateAction()`
 - `action-builder.ts`: core execution engine: runs the middleware stack, validates input/output via Standard Schema, handles errors
+- `deep-merge.ts`: dependency-free `deepmerge()` used to merge middleware context objects (inlined from `deepmerge-ts` to keep the package free of runtime dependencies)
 - `middleware.ts`: `createMiddleware()` for standalone middleware definitions
 - `validation-errors.ts`: error formatting and flattening utilities
 - `utils.ts`: utility constants (`DEFAULT_SERVER_ERROR_MESSAGE`) and helpers

--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
 		"@changesets/changelog-github": "^0.6.0",
 		"@changesets/cli": "^2.31.0"
 	},
-	"packageManager": "pnpm@11.1.0"
+	"packageManager": "pnpm@11.3.0"
 }

--- a/packages/next-safe-action/package.json
+++ b/packages/next-safe-action/package.json
@@ -69,9 +69,6 @@
 	"engines": {
 		"node": ">=18.17"
 	},
-	"dependencies": {
-		"deepmerge-ts": "catalog:"
-	},
 	"devDependencies": {
 		"@testing-library/dom": "catalog:",
 		"@testing-library/react": "catalog:",

--- a/packages/next-safe-action/src/__tests__/deep-merge.test.ts
+++ b/packages/next-safe-action/src/__tests__/deep-merge.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "vitest";
+import { deepmerge } from "../deep-merge";
+
+describe("deepmerge - records", () => {
+	test("merges nested records recursively, later value wins on conflict", () => {
+		const result = deepmerge({ config: { timeout: 5000, retries: 3 } }, { config: { timeout: 10000 } });
+
+		// `retries` from the first object survives, `timeout` from the second wins.
+		expect(result).toStrictEqual({ config: { timeout: 10000, retries: 3 } });
+	});
+
+	test("preserves keys present in only one object", () => {
+		const result = deepmerge({ a: 1, only: "left" }, { a: 2, extra: "right" });
+
+		expect(result).toStrictEqual({ a: 2, only: "left", extra: "right" });
+	});
+
+	test("merges deeply nested objects across three levels", () => {
+		const result = deepmerge(
+			{ level1: { level2: { level3: { keep: 1, override: "old" } } } },
+			{ level1: { level2: { level3: { override: "new", added: 2 } } } }
+		);
+
+		expect(result).toStrictEqual({
+			level1: { level2: { level3: { keep: 1, override: "new", added: 2 } } },
+		});
+	});
+
+	test("does not mutate the input objects and returns fresh nested objects", () => {
+		const a = { nested: { x: 1 } };
+		const b = { nested: { y: 2 } };
+
+		const result = deepmerge(a, b);
+
+		expect(result).toStrictEqual({ nested: { x: 1, y: 2 } });
+		expect(a).toStrictEqual({ nested: { x: 1 } });
+		expect(b).toStrictEqual({ nested: { y: 2 } });
+		expect(result).not.toBe(a);
+		expect((result as { nested: object }).nested).not.toBe(a.nested);
+	});
+});
+
+describe("deepmerge - primitives and mismatched types", () => {
+	test("primitive values: the last one wins", () => {
+		expect(deepmerge({ x: 1 }, { x: 2 })).toStrictEqual({ x: 2 });
+		expect(deepmerge({ x: "a" }, { x: "b" })).toStrictEqual({ x: "b" });
+		expect(deepmerge({ x: true }, { x: false })).toStrictEqual({ x: false });
+	});
+
+	test("record vs array: the last one wins (no merge)", () => {
+		expect(deepmerge({ x: { a: 1 } }, { x: [1, 2] })).toStrictEqual({ x: [1, 2] });
+	});
+
+	test("primitive vs record: the last one wins", () => {
+		expect(deepmerge({ x: 5 }, { x: { a: 1 } })).toStrictEqual({ x: { a: 1 } });
+	});
+
+	test("array vs record: the last one wins", () => {
+		expect(deepmerge({ x: [1] }, { x: { a: 1 } })).toStrictEqual({ x: { a: 1 } });
+	});
+
+	test("null and undefined values: the last one wins", () => {
+		expect(deepmerge({ x: { a: 1 } }, { x: null })).toStrictEqual({ x: null });
+		expect(deepmerge({ x: 1 }, { x: undefined })).toStrictEqual({ x: undefined });
+	});
+});
+
+describe("deepmerge - arrays", () => {
+	test("concatenates arrays nested in records", () => {
+		expect(deepmerge({ tags: ["a", "b"] }, { tags: ["c"] })).toStrictEqual({ tags: ["a", "b", "c"] });
+	});
+
+	test("concatenates top-level arrays", () => {
+		expect(deepmerge([1, 2], [3, 4])).toStrictEqual([1, 2, 3, 4]);
+	});
+});
+
+describe("deepmerge - Sets and Maps", () => {
+	test("unions Sets", () => {
+		expect(deepmerge({ s: new Set([1, 2]) }, { s: new Set([2, 3]) })).toStrictEqual({
+			s: new Set([1, 2, 3]),
+		});
+	});
+
+	test("combines Maps, later entry wins on key conflict", () => {
+		const result = deepmerge(
+			{ m: new Map([["a", 1]]) },
+			{
+				m: new Map([
+					["a", 2],
+					["b", 3],
+				]),
+			}
+		);
+
+		expect(result).toStrictEqual({
+			m: new Map([
+				["a", 2],
+				["b", 3],
+			]),
+		});
+	});
+});
+
+describe("deepmerge - keys", () => {
+	test("preserves symbol keys, later value winning", () => {
+		const sym = Symbol("token");
+		const result = deepmerge({ [sym]: 1, keep: "a" }, { [sym]: 2 }) as Record<PropertyKey, unknown>;
+
+		expect(result[sym]).toBe(2);
+		expect(result.keep).toBe("a");
+	});
+
+	test("does not pollute Object.prototype via a malicious __proto__ key", () => {
+		const malicious = JSON.parse('{ "__proto__": { "polluted": true } }');
+
+		const result = deepmerge({ safe: 1 }, malicious) as Record<string, unknown>;
+
+		// The prototype chain must be untouched.
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		expect(Object.prototype.hasOwnProperty.call(Object.prototype, "polluted")).toBe(false);
+		expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+		// The non-malicious key is still merged normally.
+		expect(result.safe).toBe(1);
+	});
+});
+
+describe("deepmerge - arity", () => {
+	test("returns the single object when called with one argument", () => {
+		expect(deepmerge({ a: 1 })).toStrictEqual({ a: 1 });
+	});
+
+	test("returns an empty object when called with no arguments", () => {
+		expect(deepmerge()).toStrictEqual({});
+	});
+
+	test("folds over more than two objects, last value winning", () => {
+		expect(deepmerge({ a: 1 }, { b: 2 }, { a: 3, c: 4 })).toStrictEqual({ a: 3, b: 2, c: 4 });
+	});
+});

--- a/packages/next-safe-action/src/__tests__/middleware-edge-cases.test.ts
+++ b/packages/next-safe-action/src/__tests__/middleware-edge-cases.test.ts
@@ -174,7 +174,7 @@ test("deep merge concatenates arrays in context", async () => {
 
 	const actualResult = await action();
 
-	// deepmerge-ts concatenates arrays by default.
+	// The deep-merge concatenates arrays by default.
 	expect(actualResult).toStrictEqual({
 		data: {
 			tags: ["auth", "logging"],

--- a/packages/next-safe-action/src/__tests__/validated-middleware-edge-cases.test.ts
+++ b/packages/next-safe-action/src/__tests__/validated-middleware-edge-cases.test.ts
@@ -193,7 +193,7 @@ test("deep merge arrays across use() and useValidated()", async () => {
 
 	const actualResult = await action({ role: "admin" });
 
-	// Arrays are concatenated by deepmerge-ts.
+	// Arrays are concatenated by the deep-merge.
 	expect(actualResult).toStrictEqual({
 		data: {
 			scopes: ["read:self", "write:all", "delete:all"],

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -1,5 +1,5 @@
-import { deepmerge } from "deepmerge-ts";
 import type {} from "zod";
+import { deepmerge } from "./deep-merge";
 import type {
 	ValidationErrorsFormat,
 	MiddlewareResult,

--- a/packages/next-safe-action/src/deep-merge.ts
+++ b/packages/next-safe-action/src/deep-merge.ts
@@ -1,0 +1,195 @@
+/*!
+ * This file is a deep-merge implementation adapted from `deepmerge-ts`
+ * (https://github.com/RebeccaStevens/deepmerge-ts). Portions of the code below, in
+ * particular the plain-record detection (`isRecord`), key collection (`getKeys`) and the
+ * recursive record merge with its `__proto__` prototype-pollution guard, are derived from
+ * that project and remain under its original license, reproduced in full below.
+ *
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2021, Rebecca Stevens
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Internal deep-merge utility.
+ *
+ * Inlined from, and trimmed down to only what this library needs of, `deepmerge-ts`, so
+ * that next-safe-action ships with zero runtime dependencies and is not exposed to
+ * supply-chain attacks targeting third-party packages.
+ *
+ * The library only ever calls `deepmerge(a, b)` with two plain middleware context objects,
+ * so this reproduces deepmerge-ts's *default* merge behavior for that case:
+ * - plain records (objects) are merged recursively;
+ * - arrays are concatenated;
+ * - Sets are unioned and Maps are combined (later entries win on key conflict);
+ * - any other or mismatched values: the last (rightmost) value wins.
+ */
+
+// `Object.prototype.toString` tags that mark a value as a plain record.
+const validRecordToStringValues = ["[object Object]", "[object Module]"];
+
+/**
+ * Whether the given value is a plain record, as opposed to an array, Set, Map, class
+ * instance, or other exotic object. Mirrors deepmerge-ts's record detection.
+ */
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+
+	if (!validRecordToStringValues.includes(Object.prototype.toString.call(value))) {
+		return false;
+	}
+
+	const { constructor } = value as { constructor?: { prototype?: unknown } };
+
+	// Objects with a null prototype (e.g. `Object.create(null)`) have no constructor.
+	if (constructor === undefined) {
+		return true;
+	}
+
+	const prototype = constructor.prototype;
+
+	if (
+		prototype === null ||
+		typeof prototype !== "object" ||
+		!validRecordToStringValues.includes(Object.prototype.toString.call(prototype))
+	) {
+		return false;
+	}
+
+	// A genuine plain object's prototype owns the standard Object.prototype methods.
+	if (!Object.hasOwn(prototype, "isPrototypeOf")) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * The union of both objects' own enumerable string keys and own symbol keys, in
+ * first-then-second insertion order.
+ */
+function getKeys(a: object, b: object): Set<PropertyKey> {
+	const keys = new Set<PropertyKey>();
+
+	for (const object of [a, b]) {
+		for (const key of [...Object.keys(object), ...Object.getOwnPropertySymbols(object)]) {
+			keys.add(key);
+		}
+	}
+
+	return keys;
+}
+
+/**
+ * Whether `object` has `property` as an own enumerable property.
+ */
+function objectHasProperty(object: object, property: PropertyKey): boolean {
+	return Object.prototype.propertyIsEnumerable.call(object, property);
+}
+
+/**
+ * Merge two values according to the default strategy described at the top of this file.
+ */
+function mergeValues(a: unknown, b: unknown): unknown {
+	if (isRecord(a) && isRecord(b)) {
+		return mergeRecords(a, b);
+	}
+
+	if (Array.isArray(a) && Array.isArray(b)) {
+		return [...a, ...b];
+	}
+
+	if (a instanceof Set && b instanceof Set) {
+		return new Set([...a, ...b]);
+	}
+
+	if (a instanceof Map && b instanceof Map) {
+		return new Map([...a, ...b]);
+	}
+
+	// Mismatched types, primitives, or any other value: the last one wins.
+	return b;
+}
+
+/**
+ * Recursively merge two plain records into a fresh object.
+ */
+function mergeRecords(a: Record<PropertyKey, unknown>, b: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> {
+	const result: Record<PropertyKey, unknown> = {};
+
+	for (const key of getKeys(a, b)) {
+		const inA = objectHasProperty(a, key);
+		const inB = objectHasProperty(b, key);
+
+		// The key is non-enumerable on both objects: nothing to merge.
+		if (!inA && !inB) {
+			continue;
+		}
+
+		let value: unknown;
+		if (inA && inB) {
+			value = mergeValues(a[key], b[key]);
+		} else if (inB) {
+			value = b[key];
+		} else {
+			value = a[key];
+		}
+
+		// Assigning to `__proto__` via `result[key] = value` would mutate the prototype
+		// instead of creating an own property, so guard against prototype pollution.
+		if (key === "__proto__") {
+			Object.defineProperty(result, key, {
+				value,
+				configurable: true,
+				enumerable: true,
+				writable: true,
+			});
+		} else {
+			result[key] = value;
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Deeply merge the given objects, with the last value winning on conflict. The library
+ * always calls this with exactly two middleware context objects.
+ */
+export function deepmerge(...objects: ReadonlyArray<object>): object {
+	let result: unknown = objects[0] ?? {};
+
+	for (let index = 1; index < objects.length; index++) {
+		result = mergeValues(result, objects[index]);
+	}
+
+	return result as object;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,6 @@ catalogs:
     '@types/react-dom':
       specifier: ^19
       version: 19.2.3
-    deepmerge-ts:
-      specifier: ^7.1.5
-      version: 7.1.5
     jsdom:
       specifier: ^26
       version: 26.1.0
@@ -379,10 +376,6 @@ importers:
         version: 4.4.3
 
   packages/next-safe-action:
-    dependencies:
-      deepmerge-ts:
-        specifier: 'catalog:'
-        version: 7.1.5
     devDependencies:
       '@testing-library/dom':
         specifier: 'catalog:'
@@ -3139,10 +3132,6 @@ packages:
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
-
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
-    engines: {node: '>=16.0.0'}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -8006,8 +7995,6 @@ snapshots:
   dedent@1.7.2: {}
 
   deep-extend@0.6.0: {}
-
-  deepmerge-ts@7.1.5: {}
 
   deepmerge@4.3.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,6 @@ catalog:
   "@types/node": ^24
   "@types/react": ^19
   "@types/react-dom": ^19
-  deepmerge-ts: ^7.1.5
   jsdom: ^26
   next: ^16.2.6
   oxfmt: ^0.48.0


### PR DESCRIPTION
# Inline `deepmerge-ts` to remove the runtime dependency

## Summary

`next-safe-action` used `deepmerge-ts` for exactly one thing: deep-merging middleware
context objects as the middleware chain runs. Given the recent wave of npm supply-chain
compromises, this PR removes that third-party runtime dependency and instead carries a
small, self-contained implementation in the repo. The core package now ships with **zero
runtime dependencies**, and only the subset of merge logic the library actually needs is
kept, so it is leaner too.

## What changed

- **New `packages/next-safe-action/src/deep-merge.ts`** — a dependency-free `deepmerge()`
  that reproduces `deepmerge-ts`'s *default* merge behavior for the two-object case the
  library uses:
  - plain records (objects) merged recursively,
  - arrays concatenated,
  - `Set`s unioned and `Map`s combined (later entries win on key conflict),
  - any other or mismatched values: the last (rightmost) value wins,
  - `__proto__` keys written via `Object.defineProperty` to guard against prototype
    pollution.
- **`action-builder.ts`** — import swapped from `deepmerge-ts` to `./deep-merge`; the two
  call sites are unchanged.
- **`package.json`** — the entire `dependencies` block removed (`deepmerge-ts` was its only
  entry), so the package now declares no runtime dependencies.
- **`pnpm-workspace.yaml`** — `deepmerge-ts` catalog entry removed; `pnpm-lock.yaml`
  regenerated (the unrelated transitive `deepmerge@4.3.1` is untouched).
- **`src/__tests__/deep-merge.test.ts`** — new unit tests (records, arrays, Sets, Maps,
  mismatched types, symbol keys, `__proto__` pollution guard, arity, immutability).
- **`AGENTS.md`** — added `deep-merge.ts` to the server-core file list; two existing test
  comments updated to stop referencing the removed package by name.

## Behavior

No behavior change. The inlined implementation matches `deepmerge-ts`'s defaults for the way
the library merges context, and the existing middleware/adapter context-merge tests pass
unchanged.

## Licensing / attribution

The inlined code is genuinely derived from `deepmerge-ts` (record detection, key collection,
the recursive record merge and its `__proto__` guard). The full **BSD-3-Clause** license
(copyright (c) 2021, Rebecca Stevens, conditions, and disclaimer) is reproduced verbatim in
the header of `deep-merge.ts` as a `/*!` legal-comment banner, which is preserved into the
built `dist/` bundle. BSD-3-Clause and the project's MIT license are compatible; the library
as a whole remains MIT.

## Verification

- `pnpm install` — lockfile clean, no `deepmerge-ts`, `deepmerge@4.3.1` retained
- `pnpm run test:lib` — full suite passes (579 core tests + all adapter tests)
- new `deep-merge.test.ts` — 18/18 pass, no type errors
- `pnpm run lint:lib` — 0 errors (new files: 0 warnings)
- `pnpm run fmt:check` — clean
- `pnpm run build:lib` — builds; `deepmerge` is inlined into `dist/index.mjs` with no
  external import, and the BSD-3-Clause notice survives into the bundle

## Changeset

Included: patch bump for `next-safe-action`.