### PR TITLE
fix(hooks): don't replay callbacks when restored from the router bfcache (React Activity)

### DIFF
--- a/.changeset/hot-tables-tease.md
+++ b/.changeset/hot-tables-tease.md
@@ -1,0 +1,5 @@
+---
+"next-safe-action": patch
+---
+
+Fix hook callbacks re-firing when a page is restored from the Next.js router bfcache (React `<Activity>`, enabled by `cacheComponents`): `onExecute`/`onSuccess`/`onError`/`onSettled`/`onNavigation` now fire once per action execution instead of replaying on every restore.

--- a/packages/next-safe-action/src/__tests__/hooks-callbacks-replay.test.tsx
+++ b/packages/next-safe-action/src/__tests__/hooks-callbacks-replay.test.tsx
@@ -1,0 +1,143 @@
+import { act, render } from "@testing-library/react";
+import { Activity } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { useAction } from "../hooks";
+import type { HookCallbacks, SingleInputActionFn } from "../hooks.types";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+type TestActionFn = SingleInputActionFn<string, undefined, undefined, { message: string }>;
+type TestCallbacks = HookCallbacks<string, undefined, undefined, { message: string }>;
+
+type ExecuteRef = { current: ((input: undefined) => void) | null };
+
+/**
+ * Renders `useAction` inside a component tree so it can be wrapped in an
+ * `<Activity>` boundary, and exposes `execute` through a mutable ref.
+ */
+function ActionHarness({
+	action,
+	callbacks,
+	executeRef,
+}: {
+	action: TestActionFn;
+	callbacks?: TestCallbacks;
+	executeRef: ExecuteRef;
+}) {
+	const { execute } = useAction(action, callbacks);
+	executeRef.current = execute;
+	return null;
+}
+
+async function flushHookTimers() {
+	await act(async () => {
+		vi.advanceTimersByTime(0);
+	});
+	await act(async () => {});
+}
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+// ─── <Activity> replay (Next.js router bfcache) ──────────────────────────────
+
+// When a page is restored from the Next.js router bfcache (`cacheComponents`),
+// React `<Activity>` preserves the hook state but cleans up and re-runs all
+// effects. The callbacks effect must not re-fire for an execution it already
+// handled. See https://github.com/next-safe-action/next-safe-action/issues/454
+describe("<Activity> hide/show (router bfcache restore)", () => {
+	test("does not replay onSuccess/onSettled for an already-handled execution", async () => {
+		const action = vi.fn<TestActionFn>().mockResolvedValue({
+			data: { message: "success" },
+		});
+		const onSuccess = vi.fn();
+		const onSettled = vi.fn();
+		const executeRef: ExecuteRef = { current: null };
+
+		const ui = (mode: "visible" | "hidden") => (
+			<Activity mode={mode}>
+				<ActionHarness action={action} callbacks={{ onSuccess, onSettled }} executeRef={executeRef} />
+			</Activity>
+		);
+
+		const { rerender } = render(ui("visible"));
+
+		act(() => {
+			executeRef.current!(undefined);
+		});
+
+		await flushHookTimers();
+
+		expect(onSuccess).toHaveBeenCalledTimes(1);
+		expect(onSettled).toHaveBeenCalledTimes(1);
+
+		// Hide, then re-show: state is preserved, effects re-run.
+		await act(async () => {
+			rerender(ui("hidden"));
+		});
+		await act(async () => {
+			rerender(ui("visible"));
+		});
+
+		await flushHookTimers();
+
+		expect(onSuccess).toHaveBeenCalledTimes(1);
+		expect(onSettled).toHaveBeenCalledTimes(1);
+
+		// A new execution after the restore fires the callbacks again.
+		act(() => {
+			executeRef.current!(undefined);
+		});
+
+		await flushHookTimers();
+
+		expect(onSuccess).toHaveBeenCalledTimes(2);
+		expect(onSettled).toHaveBeenCalledTimes(2);
+	});
+
+	test("does not replay onError/onSettled for an already-handled execution", async () => {
+		const action = vi.fn<TestActionFn>().mockResolvedValue({
+			serverError: "Server error",
+		});
+		const onError = vi.fn();
+		const onSettled = vi.fn();
+		const executeRef: ExecuteRef = { current: null };
+
+		const ui = (mode: "visible" | "hidden") => (
+			<Activity mode={mode}>
+				<ActionHarness action={action} callbacks={{ onError, onSettled }} executeRef={executeRef} />
+			</Activity>
+		);
+
+		const { rerender } = render(ui("visible"));
+
+		act(() => {
+			executeRef.current!(undefined);
+		});
+
+		await flushHookTimers();
+
+		expect(onError).toHaveBeenCalledTimes(1);
+		expect(onSettled).toHaveBeenCalledTimes(1);
+
+		// Hide, then re-show: state is preserved, effects re-run.
+		await act(async () => {
+			rerender(ui("hidden"));
+		});
+		await act(async () => {
+			rerender(ui("visible"));
+		});
+
+		await flushHookTimers();
+
+		expect(onError).toHaveBeenCalledTimes(1);
+		expect(onSettled).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/next-safe-action/src/hooks-utils.ts
+++ b/packages/next-safe-action/src/hooks-utils.ts
@@ -87,8 +87,40 @@ export const useActionCallbacks = <ServerError, Schema extends StandardSchemaV1 
 	const onSettled = useCallbackRef(cb?.onSettled);
 	const onNavigation = useCallbackRef(cb?.onNavigation);
 
+	// Snapshot of the execution state the callbacks last fired for. Every
+	// execution replaces these values with fresh identities (`setResult`,
+	// `setClientInput`, ...), so an effect re-run where all of them are
+	// identical to the snapshot is a replay of already-handled state — e.g.
+	// React `<Activity>` restoring a page from the Next.js router bfcache
+	// (state preserved, effects re-fired) — never a new status transition.
+	// Kept in a ref because refs survive the `<Activity>` hide/show cycle.
+	const lastHandledRef = React.useRef<{
+		status: HookActionStatus;
+		result: SafeActionResult<ServerError, Schema, ShapedErrors, Data>;
+		input: InferInputOrDefault<Schema, undefined>;
+		navigationError: Error | null;
+		thrownError: Error | null;
+	} | null>(null);
+
 	// Execute hook callbacks as non-visual side effects.
 	React.useEffect(() => {
+		const last = lastHandledRef.current;
+
+		// Fire callbacks once per execution: skip replays of an
+		// already-handled execution state (see `lastHandledRef` above).
+		if (
+			last &&
+			last.status === status &&
+			last.result === result &&
+			last.input === input &&
+			last.navigationError === navigationError &&
+			last.thrownError === thrownError
+		) {
+			return;
+		}
+
+		lastHandledRef.current = { status, result, input, navigationError, thrownError };
+
 		const executeCallbacks = async () => {
 			switch (status) {
 				case "executing":


### PR DESCRIPTION
## Summary

Fixes #454 — `useAction` hook callbacks (`onExecute`/`onSuccess`/`onError`/`onSettled`/`onNavigation`) re-fire, without any new action execution, every time the page that owns the hook is restored from the Next.js App Router bfcache (React `<Activity>`, enabled by `cacheComponents` in Next.js 16).

## Problem

With `cacheComponents: true`, the App Router keeps the last visited pages alive inside a React `<Activity>` boundary: on navigation the page's React state is **preserved** while its effects are cleaned up, and on restore the effects **re-run**.

`useActionCallbacks` fires the callbacks from a `useEffect` keyed on `status`/`result`/`input`. The preserved hook state still says `status === "hasSucceeded"`, so the effect re-run calls `onSuccess` (and `onSettled`) again — the effect cannot tell a status *transition* apart from a *replay* of already-handled state. Any flow that toasts from `onSuccess`/`onError` (the use case shown in the docs) replays its notifications on every back-navigation.

Minimal reproduction: https://github.com/LouisCuvelier/next-safe-action-bfcache-callback-replay (reproduces in dev and production builds).

## Solution

Keep a snapshot of the execution state the callbacks last fired for (`status`, `result`, `input`, `navigationError`, `thrownError`) in a ref, and bail out of the effect when it matches.

Every execution replaces those values with fresh identities (`setResult(res ?? {})`, `setClientInput(input)`, …), so an effect re-run where **all** of them are identical to the snapshot can only be a replay — `<Activity>` restore, StrictMode — never a new transition. Refs survive the `<Activity>` hide/show cycle, which is exactly why the guard holds across a bfcache restore while `useState` state is preserved too.

No public API change. Real executions are unaffected: first success, re-submit after success (fresh `result` identity), error → retry, and `reset()` all keep firing callbacks as before — covered by the existing suite.

## Tests

- New `hooks-callbacks-replay.test.tsx`: renders `useAction` inside an `<Activity>` boundary, executes once, toggles `mode` `visible → hidden → visible`, and asserts `onSuccess`/`onError`/`onSettled` fired exactly once — then asserts a *new* execution after the restore still fires them again. Both tests fail on `main` ("expected to be called 1 times, but got 2 times") and pass with the fix.
- `pnpm run test:lib`, `pnpm run lint:lib`, and `pnpm run fmt:check` all pass.

## Changeset

Patch bump for `next-safe-action` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
