### PR TITLE
fix(types): accept safe actions directly in the form action prop (#372)

### DIFF
--- a/.changeset/fix-form-action-prop.md
+++ b/.changeset/fix-form-action-prop.md
@@ -1,0 +1,5 @@
+---
+"next-safe-action": patch
+---
+
+fix(types): accept safe actions directly in the `<form action>` prop (#372)

--- a/packages/next-safe-action/src/__tests__/types/form-action-compat.test-d.ts
+++ b/packages/next-safe-action/src/__tests__/types/form-action-compat.test-d.ts
@@ -1,0 +1,33 @@
+import { expectTypeOf, test } from "vitest";
+import type { FormHTMLAttributes } from "react";
+import { z } from "zod";
+import { createSafeActionClient } from "../..";
+
+// Regression tests for issue #372:
+// A safe action passed directly to <form action={...}> should be type-compatible.
+//
+// React's form `action` prop is typed as:
+//   string | undefined | ((formData: FormData) => void | Promise<void>) | DO_NOT_USE...
+//
+// SafeActionFn returns Promise<SafeActionResult> (not Promise<void>), so without
+// augmenting DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS, passing a
+// safe action directly to the form action prop produces a TS error.
+
+type FormActionProp = FormHTMLAttributes<HTMLFormElement>["action"];
+
+const ac = createSafeActionClient();
+
+test("safe action with FormData input is assignable to the form element action prop", () => {
+	const action = ac
+		.inputSchema(z.custom<FormData>())
+		.action(async () => {});
+
+	// This MUST compile without error (issue #372)
+	expectTypeOf(action).toMatchTypeOf<FormActionProp>();
+});
+
+test("safe action with no schema is assignable to the form element action prop", () => {
+	const action = ac.action(async () => {});
+
+	expectTypeOf(action).toMatchTypeOf<FormActionProp>();
+});

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -9,6 +9,18 @@ import type {
 import type { MaybePromise, Prettify } from "./utils.types";
 import type { HandleValidationErrorsShapeFn, ValidationErrors } from "./validation-errors.types";
 
+// Augment React's form action extension point so that `SafeActionFn` and
+// `SafeStateActionFn` (which return `Promise<SafeActionResult>` instead of
+// `Promise<void>`) are accepted by the `<form action={...}>` prop without
+// requiring a manual wrapper.  The `DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS`
+// interface is the React-blessed escape hatch for server-action libraries.
+// See: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/main/types/react/index.d.ts
+declare module "react" {
+	interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS {
+		nextSafeActionFn: (...args: any[]) => Promise<SafeActionResult<any, any, any, any>>;
+	}
+}
+
 /**
  * Type of the default validation errors shape passed to `createSafeActionClient` via `defaultValidationErrorsShape`
  * property.


### PR DESCRIPTION
Fixes #372.

**Problem:** passing a safe action straight to `<form action={...}>` raises a TS2322 — `SafeActionFn` returns `Promise<SafeActionResult<...>>`, which isn't assignable to the form `action` prop's expected `Promise<void>`.

**Fix (type-level only, zero runtime):** augment React's blessed escape-hatch interface `DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS` from `index.types.ts`, so any `SafeActionResult`-returning function is structurally accepted wherever a form `action` is expected. Scoped to safe-action fns (not arbitrary `Promise<any>`) to keep the broadening minimal — this is the React-sanctioned mechanism server-action libraries use for exactly this case.

**Verified locally:** `tsc --noEmit` clean; full suite green (583 tests, incl. 235 type tests + a new `form-action-compat` type test).

---

Came across next-safe-action and noticed #372 had been open a while, so I went ahead and fixed it. No strings — I just liked the lib. That said, this is the kind of work I do (I'm with **Choreless** — we fix and ship code for small teams), so if you ever want an extra pair of hands, I'm around. Either way, hope it helps. — Charles
