### PR TITLE
docs(form-actions): document passing a safe action directly to the form action prop

### DIFF
--- a/apps/docs/content/docs/guides/form-actions.mdx
+++ b/apps/docs/content/docs/guides/form-actions.mdx
@@ -261,6 +261,40 @@ export default function LoginForm() {
 - **Use `useStateAction`** when you need previous result access (`prevResult` in server code), you're building forms with rich callbacks and status tracking, or you want the `<form action={formAction}>` pattern with full DX.
 - **Use `useActionState` directly** when you need no-JS progressive enhancement, or you want the simplest possible form setup and don't need lifecycle callbacks.
 
+## Passing an action directly to the `action` prop
+
+If you try to pass a plain action (created with `.action()`) straight into `<form action={...}>`, TypeScript rejects it:
+
+```tsx title="src/app/login.tsx"
+<form action={loginAction}>
+//          ^ Type 'SafeActionFn<...>' is not assignable to type 'string | ((formData: FormData) => void | Promise<void>)'.
+```
+
+This happens because React validates the `action` prop against an internal, **experimental** interface named `DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS`. Out of the box that interface doesn't know about a `SafeActionFn`, so the action's `Promise<SafeActionResult<...>>` return type isn't recognized as a valid form action.
+
+If you want to pass an action to the `action` prop without going through a hook (`useStateAction`, `useActionState`) or casting at the call site, you can teach React's types about it by augmenting that interface in your own application code:
+
+```ts title="src/types/react.d.ts"
+import type { SafeActionResult } from "next-safe-action";
+
+declare module "react" {
+	interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS {
+		// oxlint-disable-next-line no-explicit-any
+		nextSafeActionFn: (...args: any[]) => Promise<SafeActionResult<any, any, any, any>>;
+	}
+}
+```
+
+With this declaration in scope, the action passes type checking when used directly:
+
+```tsx title="src/app/login.tsx"
+<form action={loginAction}>{/* ... */}</form>
+```
+
+<Callout type="warn">
+**This opts you into an unstable React interface.** As the name shouts, `DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS` is an internal, experimental React type with no stability guarantee — its shape (or name) can change between React versions, which would break this augmentation. next-safe-action does **not** apply this augmentation for you, precisely so you opt in knowingly and keep that risk in your own codebase. If you'd rather not depend on an experimental interface, use `useStateAction` or React's `useActionState` (see the tabs above), which keep the action behind a stable hook API.
+</Callout>
+
 ## What's next?
 
 <Cards>

--- a/apps/docs/content/docs/guides/form-actions.mdx
+++ b/apps/docs/content/docs/guides/form-actions.mdx
@@ -279,7 +279,6 @@ import type { SafeActionResult } from "next-safe-action";
 
 declare module "react" {
 	interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS {
-		// oxlint-disable-next-line no-explicit-any
 		nextSafeActionFn: (...args: any[]) => Promise<SafeActionResult<any, any, any, any>>;
 	}
 }
@@ -292,7 +291,7 @@ With this declaration in scope, the action passes type checking when used direct
 ```
 
 <Callout type="warn">
-**This opts you into an unstable React interface.** As the name shouts, `DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS` is an internal, experimental React type with no stability guarantee — its shape (or name) can change between React versions, which would break this augmentation. next-safe-action does **not** apply this augmentation for you, precisely so you opt in knowingly and keep that risk in your own codebase. If you'd rather not depend on an experimental interface, use `useStateAction` or React's `useActionState` (see the tabs above), which keep the action behind a stable hook API.
+**This opts you into an unstable React interface.** As the name shouts, `DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS` is an internal, experimental React type with no stability guarantee. Its shape (or name) can change between React versions, which would break this augmentation. next-safe-action does **not** apply this augmentation for you, precisely so you opt in knowingly and keep that risk in your own codebase. If you'd rather not depend on an experimental interface, use `useStateAction` or React's `useActionState` (see the tabs above), which keep the action behind a stable hook API.
 </Callout>
 
 ## What's next?


### PR DESCRIPTION
Follow-up to the discussion in #459.

In that PR we explored adding a `declare module "react"` augmentation of `DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS` inside the library so a `SafeActionFn` could be passed straight into `<form action={...}>`. We landed on the safer call you proposed: **don't ship the augmentation from the lib** (it would pin next-safe-action's types to an unstable React interface and force the broadening onto every consumer), and instead **document the type fix as an app-side recipe** so the user opts into that experimental interface knowingly.

This PR does exactly that.

## What it adds

A new section in **Form actions** (`apps/docs/content/docs/guides/form-actions.mdx`), after the "When to use each approach" table:

- Shows the TS error you hit when passing a plain `.action()` result to the `action` prop.
- Explains *why* — React validates that prop against the experimental `DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS` interface, which doesn't know about a `SafeActionFn`.
- Gives the user-side `declare module "react"` recipe to broaden it.
- A `Callout type="warn"` spelling out the caveat: it's an unstable/experimental React interface that can change between versions, the lib intentionally doesn't apply it for you, and `useStateAction` / `useActionState` remain the stable-API alternatives.

## Scope

Docs only — one file, +34 lines, no library code touched. Matches the existing `Steps`/`Callout`/`title=` style on the page; `SafeActionResult` is imported from the package root the same way other docs reference exported types.

One open question for you: I put this inline in the Form actions guide since that's where the `<form action={...}>` patterns live. If you'd rather it sit as a Troubleshooting accordion (next to the other form-action gotcha), happy to move it — just say the word.

— Charles
